### PR TITLE
Output person IDs rather than member IDs.

### DIFF
--- a/pyscraper/debate/division.py
+++ b/pyscraper/debate/division.py
@@ -100,7 +100,7 @@ def MpList(fsm, vote, stampurl, sdate):
 				print "division.py: no match for", fnam, cons, sdate
 				raise ContextException("No match on name", stamp=stampurl, fragment=fnam)
 			#print fnam, " --> ", remadename.encode("latin-1")
-			res.append('\t<mpname id="%s" vote="%s">%s</mpname>' % (mpid, vote, FixHTMLEntities(fssf)))
+			res.append('\t<mpname person_id="%s" vote="%s">%s</mpname>' % (mpid, vote, FixHTMLEntities(fssf)))
 
 	# now we have to check if the multimatched names were all exhausted
 	for ids in multimatches:
@@ -136,7 +136,7 @@ def MpTellerList(fsm, vote, stampurl, sdate):
                         #print fssf, " ++> ", remadename.encode("latin-1")
 			if not mpid:
 				raise ContextException("teller name bad match", stamp=stampurl, fragment=fssf)
-			res.append('\t<mpname id="%s" vote="%s" teller="yes">%s</mpname>' % (mpid, vote, FixHTMLEntities(fssf)))
+			res.append('\t<mpname person_id="%s" vote="%s" teller="yes">%s</mpname>' % (mpid, vote, FixHTMLEntities(fssf)))
 
 	return res
 

--- a/pyscraper/filtersentence.py
+++ b/pyscraper/filtersentence.py
@@ -210,7 +210,7 @@ def TokenHonFriend(mhonfriend, phrtok):
 	orgname = res[1]
 
 	# if you put the .encode("latin-1") on the res[1] it doesn't work when there are strange characters.
-	return ('phrase', (' class="honfriend" id="%s" name="%s"' % (nid, orgname)).encode("latin-1"))
+	return ('phrase', (' class="honfriend" person_id="%s" name="%s"' % (nid, orgname)).encode("latin-1"))
 
 
 

--- a/pyscraper/gidmatching.py
+++ b/pyscraper/gidmatching.py
@@ -54,7 +54,7 @@ def FactorChanges(flatb, scrapeversion):
 		assert chk[0] == chk[3]  # chunk type (this can fail if due to the lack of two \n's between the two labels, and thus detects an empty speech, which should not be there.  
 		essxindx.append(len(essxlist))
 		essxlist.append("HEADING-" + chk[0])
-		speaker = re.search('nospeaker="true"|speakerid="[^"]*"', chk[1]).group(0)
+		speaker = re.search('nospeaker="true"|(?:speakerid|person_id)="[^"]*"', chk[1]).group(0)
 		essxlist.append(speaker)
 
 		if re.match("oral-heading|major-heading|minor-heading", chk[0]):
@@ -81,7 +81,7 @@ def FactorChanges(flatb, scrapeversion):
 	for qb in flatb:
 		essflatbindx.append(len(essflatblist))
 		essflatblist.append("HEADING-" + qb.typ)
-		essflatblist.append(re.search('nospeaker="true"|speakerid="[^"]*"', qb.speaker).group(0))
+		essflatblist.append(re.search('nospeaker="true"|(?:speakerid|person_id)="[^"]*"', qb.speaker).group(0))
 
 		if re.match("oral-heading|major-heading|minor-heading", qb.typ):
 			heading = ("".join(qb.stext)).strip()

--- a/pyscraper/lords/divisions.py
+++ b/pyscraper/lords/divisions.py
@@ -76,7 +76,7 @@ def LordsFilterDivision(text, stampurl, sdate):
 			if not lfss:
 				raise ContextException("no name on line", stamp=stampurl, fragment=fss)
 			lordid = lordsList.MatchRevName(lfss, sdate, stampurl)
-			lordw = '\t<lord id="%s" vote="%s"%s>%s</lord>' % (lordid, contstate, tels, FixHTMLEntities(fss))
+			lordw = '\t<lord person_id="%s" vote="%s"%s>%s</lord>' % (lordid, contstate, tels, FixHTMLEntities(fss))
 
 			if contstate == 'content':
 				contentlords.append(lordw)

--- a/pyscraper/lords/resolvenames.py
+++ b/pyscraper/lords/resolvenames.py
@@ -201,7 +201,7 @@ class LordsList(xml.sax.handler.ContentHandler):
 			raise ContextException("unknown lord %s %s %s %s" % (ltitle, llordname, llordofname, stampurl), stamp=stampurl, fragment=lname)
 
 		assert len(res) == 1
-		return res[0]["id"]
+		return self.membertoperson(res[0]["id"])
 
 
 	def GetLordIDfname(self, name, loffice, sdate, stampurl=None):
@@ -212,7 +212,7 @@ class LordsList(xml.sax.handler.ContentHandler):
                         name = self.aliases[name]
 
                 if name == "Queen":
-                        return "uk.org.publicwhip/royal/-1"
+                        return "uk.org.publicwhip/person/13935"
 
 		hom = honcompl.match(name)
 		if not hom:

--- a/pyscraper/lords/speakers.py
+++ b/pyscraper/lords/speakers.py
@@ -104,7 +104,7 @@ def LordsFilterSpeakers(fout, text, sdate):
 
 		# get rid of some standard ones
 		if re.match('the lord chancellor|noble lords|a noble lord|a noble baroness|the speaker(?i)', name):
-			fout.write('<speaker speakerid="%s" speakername="%s">%s</speaker>' % ('unknown', name, name))
+			fout.write('<speaker person_id="%s" speakername="%s">%s</speaker>' % ('unknown', name, name))
 			continue
 
 
@@ -120,15 +120,15 @@ def LordsFilterSpeakers(fout, text, sdate):
 			name = officematches[loffice]
 
 		if regenericspeak.match(name):
-			fout.write('<speaker speakerid="%s" speakername="%s">%s</speaker>' % ('unknown', name, name))
+			fout.write('<speaker person_id="%s" speakername="%s">%s</speaker>' % ('unknown', name, name))
 			continue
 
 		lsid = lordsList.GetLordIDfname(name, loffice=loffice, sdate=sdate, stampurl=stampurl)  # maybe throw the exception on the outside
 
                 if not lsid:
-                        fout.write('<speaker speakerid="unknown" error="No match" speakername="%s" colon="%s">%s</speaker>' % (name, colon, name))
+                        fout.write('<speaker person_id="unknown" error="No match" speakername="%s" colon="%s">%s</speaker>' % (name, colon, name))
                 else:
-                        fout.write('<speaker speakerid="%s" speakername="%s" colon="%s">%s</speaker>' % (lsid, name, colon, name))
+                        fout.write('<speaker person_id="%s" speakername="%s" colon="%s">%s</speaker>' % (lsid, name, colon, name))
 
                 if namec.group('maiden'):
                         fout.write('<i>%s</i>' % namec.group('maiden'))

--- a/pyscraper/ni/parse.py
+++ b/pyscraper/ni/parse.py
@@ -487,7 +487,7 @@ class ParseDayJSON(ParseDayParserBase):
             if 'id' in self.speaker:
                 speaker_str = self.speaker['id']
             elif 'name' in self.speaker:
-                speaker_str = 'speakerid="unknown" speakername="%s"' % self.speaker['name']
+                speaker_str = 'person_id="unknown" speakername="%s"' % self.speaker['name']
             else:
                 speaker_str = 'nospeaker="true"'
             timestamp = self.speaker.get('ts', '')

--- a/pyscraper/ni/resolvenames.py
+++ b/pyscraper/ni/resolvenames.py
@@ -247,7 +247,7 @@ class MemberList(xml.sax.handler.ContentHandler):
 			if not re.search('Some Members|A Member|Several Members|Members', input):
 				# import pdb;pdb.set_trace()
 				raise ContextException, "No matches %s" % (input)
-			return None, 'speakerid="unknown" error="No match" speakername="%s"' % (input)
+			return None, 'person_id="unknown" error="No match" speakername="%s"' % (input)
 		if len(ids) > 1 and 'uk.org.publicwhip/member/90355' in ids:
 			# Special case for 8th May, when Mr Hay becomes Speaker
 			if input == 'Mr Hay':
@@ -271,7 +271,7 @@ class MemberList(xml.sax.handler.ContentHandler):
 			for id in ids:
 				names += id + " " + self.members[id]["firstname"] + " " + self.members[id]["lastname"] + " (" + self.members[id]["constituency"] + ") "
 			raise ContextException, "Multiple matches %s, possibles are %s" % (input, names)
-			return None, 'speakerid="unknown" error="Matched multiple times" speakername="%s"' % (input)
+			return None, 'person_id="unknown" error="Matched multiple times" speakername="%s"' % (input)
 		for id in ids:
 			pass
 		remadename = self.members[id]["lastname"]
@@ -281,7 +281,8 @@ class MemberList(xml.sax.handler.ContentHandler):
 			remadename = self.members[id]["title"] + " " + remadename
 		if self.members[id]["party"] == "Speaker" and re.search("Speaker", input):
 			remadename = input
-		return id, 'speakerid="%s" speakername="%s"%s' % (id, remadename, speakeroffice)
+		person_id = self.membertoperson(id)
+		return person_id, 'person_id="%s" speakername="%s"%s' % (person_id, remadename, speakeroffice)
 
 	def cleardebatehistory(self):
 		self.debatenamehistory = []

--- a/pyscraper/regmem/filter.py
+++ b/pyscraper/regmem/filter.py
@@ -44,7 +44,7 @@ def RunRegmemFilters2010(fout, text, sdate, sdatever):
                 (id, remadename, remadecons) = memberList.matchfullnamecons(firstname + " " + lastname, constituency, sdate)
                 if not id:
                         raise ContextException, "Failed to match name %s %s (%s) date %s\n" % (firstname, lastname, constituency, sdate)
-                fout.write(('<regmem personid="%s" memberid="%s" membername="%s" date="%s">\n' % (memberList.membertoperson(id), id, remadename, sdate)).encode("latin-1"))
+                fout.write(('<regmem personid="%s" membername="%s" date="%s">\n' % (id, remadename, sdate)).encode("latin-1"))
                 memberset.add(id)
                 category = None
                 categoryname = None
@@ -179,7 +179,7 @@ def RunRegmemFilters(fout, text, sdate, sdatever):
                         if needmemberend:
                                 fout.write('</regmem>\n')                                
                                 needmemberend = False
-                        fout.write(('<regmem personid="%s" memberid="%s" membername="%s" date="%s">\n' % (memberList.membertoperson(id), id, remadename, sdate)).encode("latin-1"))
+                        fout.write(('<regmem personid="%s" membername="%s" date="%s">\n' % (id, remadename, sdate)).encode("latin-1"))
                         memberset.add(id)
                         needmemberend = True
                         category = None

--- a/pyscraper/sp/parse-official-reports-new.py
+++ b/pyscraper/sp/parse-official-reports-new.py
@@ -90,7 +90,7 @@ def is_division_way(element, report_date=None):
             person_name = m.group(1).title()
             person_id = None
             if report_date:
-                person_id = get_unique_speaker_id(person_name, report_date)
+                person_id = get_unique_person_id(person_name, report_date)
             return ('FOR', person_name, person_id)
         else:
             m = re.search(r'FOR OPTION (\d+)$', tidied)
@@ -144,7 +144,7 @@ member_vote_just_constituency_re = re.compile('''
         $                               # ... end of the string
 ''', re.VERBOSE)
 
-def get_unique_speaker_id(tidied_speaker, on_date):
+def get_unique_person_id(tidied_speaker, on_date):
     ids = memberList.match_whole_speaker(tidied_speaker,str(on_date))
     if ids is None:
         # This special return value (None) indicates that the speaker
@@ -174,7 +174,7 @@ def get_unique_speaker_id(tidied_speaker, on_date):
                 return final_id
             else:
                 log_speaker(tidied_speaker,str(on_date),"genuine ambiguity")
-                # self.speaker_id = None
+                # self.person_id = None
 
 def is_member_vote(element, vote_date, expecting_a_vote=True):
     """Returns a speaker ID if this looks like a member's vote in a division
@@ -232,14 +232,14 @@ def is_member_vote(element, vote_date, expecting_a_vote=True):
     if not reformed_name:
         return None
 
-    speaker_id = get_unique_speaker_id(reformed_name, str(vote_date))
+    person_id = get_unique_person_id(reformed_name, str(vote_date))
 
-    if speaker_id is None and expecting_a_vote:
+    if person_id is None and expecting_a_vote:
         print "reformed_name is:", reformed_name
         print "vote_date is:", vote_date
         raise Exception, "A voting member '%s' couldn't be resolved" % (reformed_name,)
     else:
-        return speaker_id
+        return person_id
 
 def log_speaker(speaker, date, message):
     if SPEAKERS_DEBUG:
@@ -405,7 +405,7 @@ class Section(object):
             return "division/%d" % id(speech_or_division)
         elif isinstance(speech_or_division, Speech):
             s = speech_or_division
-            return s.speaker_id or s.speaker_name or "nospeaker"
+            return s.person_id or s.speaker_name or "nospeaker"
         else:
             raise Exception, "Unknown type %s passed to group_by_key" % (type(speech_or_division),)
 
@@ -490,16 +490,16 @@ class Speech(object):
         self.last_time = last_time
         self.url = url
         self.paragraphs = []
-        self.speaker_id = None
+        self.person_id = None
         if self.speaker_name:
-            self.update_speaker_id(speaker_name)
+            self.update_person_id(speaker_name)
 
     def empty(self):
         return 0 == len(self.paragraphs)
 
-    def update_speaker_id(self, tidied_speaker):
-        final_id = get_unique_speaker_id(tidied_speaker, self.speech_date)
-        self.speaker_id = final_id
+    def update_person_id(self, tidied_speaker):
+        final_id = get_unique_person_id(tidied_speaker, self.speech_date)
+        self.person_id = final_id
         self.speaker_name = tidied_speaker
 
     speakers_so_far = []
@@ -513,10 +513,10 @@ class Speech(object):
                       'id': speech_id}
         if self.speaker_name:
             attributes['speakername'] = self.speaker_name
-            if self.speaker_id:
-                attributes['speakerid'] = self.speaker_id
+            if self.person_id:
+                attributes['person_id'] = self.person_id
             else:
-                attributes['speakerid'] = 'unknown'
+                attributes['person_id'] = 'unknown'
         else:
             attributes['nospeaker'] = 'true'
         result = etree.Element("speech", **attributes)

--- a/pyscraper/sp/parse-written-answers.py
+++ b/pyscraper/sp/parse-written-answers.py
@@ -81,7 +81,7 @@ def paragraphs_in_tag(t):
 class QuestionOrReply:
     def __init__(self,sp_id,sp_name,parser):
         self.speaker_name = None
-        self.speaker_id = None
+        self.person_id = None
         self.paragraphs = []
         self.sp_id = sp_id
         self.sp_name = sp_name
@@ -111,7 +111,7 @@ class QuestionOrReply:
         if self.sp_id:
             question_id_info = ' spid="%s"' % ( self.sp_id )
         if self.speaker_name:
-            speaker_info = 'speakerid="%s" speakername="%s"' % ( self.speaker_id, self.speaker_name )
+            speaker_info = 'person_id="%s" speakername="%s"' % ( self.person_id, self.speaker_name )
         else:
             speaker_info = 'nospeaker="True"'
         holding_info = ''
@@ -226,11 +226,11 @@ class Parser:
         self.ensure_current_question_or_answer()
         self.current_question_or_reply.add_to_paragraph(s)
             
-    def set_speaker(self,speaker_name,speaker_id):
+    def set_speaker(self,speaker_name,person_id):
         if verbose: print "=== SPEAKER: "+speaker_name
         self.ensure_current_question_or_answer()
         self.current_question_or_reply.speaker_name = speaker_name
-        self.current_question_or_reply.speaker_id = speaker_id
+        self.current_question_or_reply.person_id = person_id
 
     def set_id(self,s):
         if verbose: print "=== ID: "+s
@@ -587,10 +587,10 @@ class Parser:
                             self.complete_question()
                         else:
                             speaker_name = re.sub('(?ims)\s*:\s*$','',speaker_name)
-                            speaker_id = self.valid_speaker(speaker_name)
-                            if speaker_name and speaker_id:
+                            person_id = self.valid_speaker(speaker_name)
+                            if speaker_name and person_id:
                                 self.complete_answer()
-                                self.set_speaker(speaker_name,speaker_id)
+                                self.set_speaker(speaker_name,person_id)
                                 for e in non_empty_contents:
                                     s = tidy_string(str(e))
                                     self.add_to_paragraph(s)

--- a/pyscraper/sp/parse.py
+++ b/pyscraper/sp/parse.py
@@ -194,7 +194,7 @@ class Speech:
         self.date = date
         self.set_colnum(colnum)
         self.paragraphs = [ ]
-        self.speakerid = None
+        self.person_id = None
         self.name = None
         self.question_number = None
         self.parser = parser
@@ -268,21 +268,21 @@ class Speech:
                             break
                     if not final_id:
                         log_speaker(tidied_speaker,str(self.date),"genuine ambiguity")
-                        self.speakerid = None
+                        self.person_id = None
 
                 if final_id:
                     parser.speakers_so_far.append(final_id)
-                    self.speakerid = final_id
+                    self.person_id = final_id
                     self.name = tidied_speaker
                 else:
-                    self.speakerid = None
+                    self.person_id = None
                     self.name = tidied_speaker
 
             else:
                 # It's something we know about, but not an MSP (e.g
                 # Lord Advocate)
                 self.name = tidied_speaker
-                self.speakerid = None
+                self.person_id = None
 
     def set_question_number(self,number):
         self.question_number = number
@@ -371,22 +371,22 @@ class Speech:
         # We only resolve from the list of MSPs in general, so make
         # George Younger a special case:
         if self.name and re.search('George Younger',self.name):
-            self.speakerid = "uk.org.publicwhip/lord/100705"
+            self.person_id = "uk.org.publicwhip/person/13029"
 
         # Also we should try to recognize Her Majesty The Queen:
         if self.name and re.search('(?ims)Her Majesty The Queen',self.name):
-            self.speakerid = "uk.org.publicwhip/royal/-1"
+            self.person_id = "uk.org.publicwhip/person/13935"
 
         # The speech id should look like:
         #    uk.org.publicwhip/spor/2003-06-26.1219.2
-        # The speaker id should look like:
-        #    uk.org.publicwhip/member/931
+        # The person id should look like:
+        #    uk.org.publicwhip/person/931
 
         if self.name:
-            if self.speakerid:
-                speaker_info = 'speakerid="%s" speakername="%s"' % ( self.speakerid, self.name )
+            if self.person_id:
+                speaker_info = 'person_id="%s" speakername="%s"' % ( self.person_id, self.name )
             else:
-                speaker_info = 'speakerid="unknown" speakername="%s"' % ( self.name )
+                speaker_info = 'person_id="unknown" speakername="%s"' % ( self.name )
         else:
             speaker_info = 'nospeaker="true"'
 

--- a/pyscraper/sp/resolvemembernames.py
+++ b/pyscraper/sp/resolvemembernames.py
@@ -16,7 +16,7 @@ class MemberList(xml.sax.handler.ContentHandler):
     def __init__(self):
         self.reloadXML()
 
-    # This will return a list of member ID strings or None.  If there
+    # This will return a list of person ID strings or None.  If there
     # are no matches, the list will be empty.  If we recognize a valid
     # speaker, but that person is not an MSP (e.g. The Convener,
     # Members, the Lord Advocate, etc.) then we return None.
@@ -105,7 +105,7 @@ class MemberList(xml.sax.handler.ContentHandler):
 
         return ids_so_far
 
-    # This will return a list of member ID strings or None.  If there
+    # This will return a list of person ID strings or None.  If there
     # are no matches, the list will be empty.  If we recognize a valid
     # speaker, but that person is not an MSP (e.g. The Convener,
 
@@ -148,7 +148,7 @@ class MemberList(xml.sax.handler.ContentHandler):
                         if m['id'] not in member_ids:
                             member_ids.append(m['id'])
                 if len(member_ids) == 1:
-                    return member_ids
+                    return map(self.membertoperson, member_ids)
 
         fullname_matches = self.fullnames.get(s)
         if fullname_matches:
@@ -162,7 +162,7 @@ class MemberList(xml.sax.handler.ContentHandler):
                 if m['id'] not in member_ids:
                     member_ids.append(m['id'])
             if len(member_ids) == 1:
-                return member_ids
+                return map(self.membertoperson, member_ids)
 
         # Now check if this begins with a title:
 
@@ -195,7 +195,7 @@ class MemberList(xml.sax.handler.ContentHandler):
                     if m['id'] not in member_ids:
                         member_ids.append(m['id'])
                 if len(member_ids) == 1:
-                    return member_ids
+                    return map(self.membertoperson, member_ids)
 
             # Or if there's a single word, then this is probably just
             # a last name:
@@ -209,7 +209,7 @@ class MemberList(xml.sax.handler.ContentHandler):
                         if m['id'] not in member_ids:
                             member_ids.append(m['id'])
                     if len(member_ids) == 1:
-                        return member_ids
+                        return map(self.membertoperson, member_ids)
 
         if not just_name:
 
@@ -224,7 +224,7 @@ class MemberList(xml.sax.handler.ContentHandler):
                         if m['id'] not in member_ids:
                             member_ids.append(m['id'])
                     if len(member_ids) == 1:
-                        return member_ids
+                        return map(self.membertoperson, member_ids)
 
         # Just return the string for people that aren't members, but
         # we know are ones we understand.
@@ -237,7 +237,7 @@ class MemberList(xml.sax.handler.ContentHandler):
             # print "Got some law officer..."
             return None
 
-        return member_ids
+        return map(self.membertoperson, member_ids)
 
     def reloadXML(self):
         # Could add some manually here:

--- a/pyscraper/splitheadingsspeakers.py
+++ b/pyscraper/splitheadingsspeakers.py
@@ -139,7 +139,7 @@ class SepHeadText:
             self.shspeak.append((self.speaker, sptext))
             # Specifically "unknown" speakers e.g. "Several hon members rose" don't
             # have text in their "speech" bit.
-            if re.match('(?:<[^>]*?>|\s)*$', sptext) and not re.match('speakerid="unknown"', self.speaker):
+            if re.match('(?:<[^>]*?>|\s)*$', sptext) and not re.match('(?:speakerid|person_id)="unknown"', self.speaker):
                 print 'Warning:: Speaker with no text ' + self.speaker
                 print self.heading
 

--- a/pyscraper/wrans/speakers.py
+++ b/pyscraper/wrans/speakers.py
@@ -146,7 +146,7 @@ def FilterWransSpeakers(fout, text, sdate):
 
 		# see if it is an explicitly bad/ambiguous name which will never match
 		if boldnamestring.find('<broken-name>') >= 0:
-			id = 'unknown'
+			person_id = 'unknown'
 			boldnamestring = boldnamestring.replace('<broken-name>', '')
 			remadename = ' speakername="%s" error="Name ambiguous in Hansard"' % (boldnamestring)
 		else:
@@ -158,25 +158,21 @@ def FilterWransSpeakers(fout, text, sdate):
 				(name, cons) = (boldnamestring, None)
 
 			# match the member to a unique identifier
-			(id, remadename, remadecons) = memberList.matchfullnamecons(name, cons, sdate, alwaysmatchcons = False)
-			if id and remadename:
+			(person_id, remadename, remadecons) = memberList.matchfullnamecons(name, cons, sdate, alwaysmatchcons = False)
+			if person_id and remadename:
 				remadename = ' speakername="%s"' % (remadename)
-			if not id:
+			if not person_id:
 				if remadename == "MultipleMatch":
                                         if boldnamestring == 'Mr. Michael Foster':
-                                                if remadecons[1] == 'uk.org.publicwhip/member/1939':
-                                                        id = remadecons[1]
-                                                        remadename = ' speakername="Michael Foster"'
-                                                        remadecons = 'Worcester'
-                                                elif remadecons[0] == 'uk.org.publicwhip/member/896':
-                                                        id = remadecons[0]
+                                                if remadecons[0] == 'uk.org.publicwhip/person/10209':
+                                                        person_id = remadecons[0]
                                                         remadename = ' speakername="Michael Foster"'
                                                         remadecons = 'Worcester'
                                         else:
-        					id = 'unknown'
+        					person_id = 'unknown'
         					remadename = ' speakername="%s" error="MultipleMatch"' % boldnamestring
 				elif boldnamestring == 'Jim Dobbin' and sdate == '2014-09-08':
-					id = 'uk.org.publicwhip/member/40316'
+					person_id = 'uk.org.publicwhip/person/10170'
 					remadename = ' speakername="Jim Dobbin"'
 				else:
 					print "  No name,const match (%s,%s)" % (name, cons)
@@ -184,8 +180,8 @@ def FilterWransSpeakers(fout, text, sdate):
 
 
 		# put record in this place
-		fs[i] = '<speaker speakerid="%s"%s>%s</speaker>\n' % \
-				(id.encode("latin-1"), remadename.encode("latin-1"), boldnamestring)
+		fs[i] = '<speaker person_id="%s"%s>%s</speaker>\n' % \
+				(person_id.encode("latin-1"), remadename.encode("latin-1"), boldnamestring)
 
 
 	# scan through everything and output it into the file


### PR DESCRIPTION
This applies to speeches, division lists, committee attendance lists,
and matched honourable friend phrases.