### PR TITLE
Detect when Parliament data hasn't arrived and warn

### DIFF
--- a/pyscraper/scrape_recess_dates.py
+++ b/pyscraper/scrape_recess_dates.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# vim:sw=4:ts=4:et:nowrap
+
+import urllib
+import mx.DateTime
+import json
+from os.path import join
+from bs4 import BeautifulSoup
+
+from miscfuncs import toppath
+
+recess_file = join(toppath, 'recessdates.json')
+
+def get_recess_dates(url):
+    page = urllib.urlopen(url)
+    content = page.read()
+    page.close()
+
+    soup = BeautifulSoup(content, 'html.parser')
+
+    dates = soup.find(id='ctl00_ctl00_FormContent_SiteSpecificPlaceholder_PageContent_ctlMainBody_wrapperDiv')
+
+    today = mx.DateTime.today().date
+    recess_dates = []
+    for row in dates.find_all('tr'):
+        cells = row.find_all('td')
+        if len(cells) == 3:
+            name = cells[0].text
+            start_date = mx.DateTime.DateFrom(cells[1].text).date
+            end_date = mx.DateTime.DateFrom(cells[2].text).date
+
+            recess_dates.append({ 'name': name, 'start': start_date, 'end': end_date})
+
+    return { 'last_update': today, 'recesses': recess_dates}
+
+urls = {
+    'lords': 'http://www.parliament.uk/about/faqs/house-of-lords-faqs/lords-recess-dates/',
+    'commons': "http://www.parliament.uk/about/faqs/house-of-commons-faqs/business-faq-page/recess-dates/"
+}
+
+data = {}
+for house in urls.keys():
+    data[house] = get_recess_dates(urls[house])
+
+with open(recess_file, 'w') as f:
+    json.dump(data, f, indent=4, sort_keys=True)
+


### PR DESCRIPTION
This adds a warning to `process_hansard.py` when it looks like we've failed to download files from Parliament. As part of this there's a script to fetch and save recess dates from Parliament which are then used to determine if we should expect any data.
