### PR TITLE
Import Social Media link from EveryPolitician

### DIFF
--- a/pyscraper/get_links_from_ep.py
+++ b/pyscraper/get_links_from_ep.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+
+import operator
+from lxml import etree
+from everypolitician import EveryPolitician
+
+
+def output_file(country, legislature, filename):
+    data = EveryPolitician().country(country).legislature(legislature)
+    output_filename = "../members/{0}.xml".format(filename)
+    root = etree.Element('publicwhip')
+
+    sorted_people = sorted(
+        data.popolo().persons,
+        key=operator.attrgetter('name')
+    )
+    for person in sorted_people:
+        parlparse_id = person.identifier_value('parlparse')
+        if parlparse_id is not None:
+            props = {}
+            if person.twitter:
+                props['twitter_username'] = person.twitter
+            if person.facebook:
+                props['facebook_page'] = person.facebook
+
+            if props:
+                props['id'] = parlparse_id
+                info = etree.Element('personinfo', props)
+                root.append(info)
+
+    et = etree.ElementTree(root)
+    et.write(output_filename, pretty_print=True)
+
+
+output_file('UK', 'Commons', 'social-media-commons')
+output_file('Scotland', 'Parliament', 'social-media-sp')
+output_file('Northern-Ireland', 'Assembly', 'social-media-ni')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+BeautifulSoup==3.2.1
+beautifulsoup4==4.3.2
+egenix-mx-base==3.2.9
+everypolitician==0.0.13
+lxml==3.4.0
+python-dateutil==2.2
+requests==2.4.3
+requests-cache==0.4.6

--- a/scripts/weeklyupdate
+++ b/scripts/weeklyupdate
@@ -40,6 +40,8 @@ cd ~/parlparse/pyscraper
 ni/wikipedia-mla.py > ../members/wikipedia-mla.xml
 cd ~/parlparse/pyscraper/sp
 ./wikipedia-msp.py > ../../members/wikipedia-msp.xml
+cd ~/parlparse/pyscraper
+../.venv/bin/python ./get_links_from_ep.py
 #cd ~/parlparse/members
 #svn -q commit -m "Weekly members scrape commit"
 


### PR DESCRIPTION
This creates new XML files for use by TheyWorkForYou's `mpinfoin.pl` which include Twitter and Facebook details from EveryPolitician data. It uses EveryPolitician's `everypolitician` library so need to run under a virtual env that has this installed with:

`pip install everypolitician`

It generates one file for MPs, MLAs and MSPs, although at the moment EP lacks the IDs for MLAs and MSPs for the file to be populated.