### PR TITLE
Improve parser detection of unhandled content 

### DIFF
--- a/pyscraper/gidmatching.py
+++ b/pyscraper/gidmatching.py
@@ -65,7 +65,7 @@ def PrepareXMLForDiff(scrapeversion):
 				if m:
 					para = m.group(1)
 				else:
-					assert re.match("\s*</?(?:table|tbody|thead|caption|divisioncount|mplist|mpname|lordlist|lord)", ps)
+					assert re.match("\s*</?(?:table|tbody|thead|caption|divisioncount|mplist|mpname|lordlist|lord|tr|td)", ps)
 					para = ps
 				essxlist.extend(re.findall("<[^>]*>|&\w+;|[^<>\s]+", para))
 

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -1751,13 +1751,13 @@ class LordsParseDayXML(BaseParseDayXML):
 
         self.root.append(tag)
 
-        paras = division.xpath('./ns:hs_Procedure', namespaces=self.ns_map)
+        paras = division.xpath('./ns:hs_Procedure | ./ns:hs_para', namespaces=self.ns_map)
         for para in paras:
             text = u''.join(para.xpath('.//text()'))
-            if re.search(r'Contents', text) or \
-                    re.search(r'Division\s*on', text):
+            if re.search(r'Contents', text):
+                self.mark_seen(para)
                 continue
-            self.parse_para(para)
+            self.parse_para_with_member(para, None)
 
     def parse_votelist(self, votes, direction, vote_list):
         for vote in votes:

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -112,6 +112,7 @@ class BaseParseDayXML(object):
         'hs_6bBillsPresented', # FIXME should grab text of following tag
         'hs_6fCntrItalHdg',
         'hs_2cSO24Application',
+        'hs_2cDebatedMotion',
     ]
     chair_headings = [
         'hs_76fChair',
@@ -126,7 +127,6 @@ class BaseParseDayXML(object):
         'hs_6bcBigBoldHdg',
     ]
     generic_headings = [
-        'hs_2cDebatedMotion',
         'hs_2cGenericHdg',
         'hs_2GenericHdg',
     ]

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -1679,6 +1679,10 @@ class LordsParseDayXML(BaseParseDayXML):
         self.mark_seen(heading)
 
     def parse_division(self, division):
+        time = division.xpath('.//ns:hs_time', namespaces=self.ns_map)
+        if len(time):
+            self.parse_time(time[0])
+
         ayes_count = \
             division.xpath('.//ns:ContentsNumber/text()', namespaces=self.ns_map)
         noes_count = \

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -979,7 +979,7 @@ class BaseParseDayXML(object):
         time_txt = u''.join(tag.xpath('.//text()'))
         if time_txt == '':
             return
-        matches = re.match('(\d+)(?:[:.](\d+))?[\xa0\s]*(am|pm)', time_txt)
+        matches = re.match('(\d+)(?:[:.\n](\d+))?[\xa0\s]*(am|pm)', time_txt)
         if matches:
             hours = int(matches.group(1))
             minutes = int(matches.group(2) or 0)

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -72,6 +72,7 @@ class LordsPimsList(LordsList):
 class BaseParseDayXML(object):
     input_root = None
     resolver = PimsList()
+    seen_elements = set()
 
     type_to_xpath = {
         'debate': (
@@ -209,6 +210,25 @@ class BaseParseDayXML(object):
             is_pre = True
 
         return is_pre
+
+    def mark_seen(self, tag):
+        if tag.get('UID'):
+            if tag.get('UID') == '17020192000008':
+                print('17020192000010')
+            self.seen_elements.add(tag.get('UID'))
+
+        if tag.get('HRSContentId'):
+            self.seen_elements.add(tag.get('HRSContentId'))
+
+    def mark_xpath_seen(self, tag, xpath):
+        inner = tag.xpath(xpath, namespaces=self.ns_map)
+        if len(inner) > 0:
+            self.mark_seen(inner[0])
+
+    def mark_xpath_all_seen(self, tag, xpath):
+        inner = tag.xpath(xpath, namespaces=self.ns_map)
+        for t in inner:
+            self.mark_seen(t)
 
     def get_tag_name_no_ns(self, tag):
         # remove annoying namespace for brevities sake
@@ -959,6 +979,9 @@ class BaseParseDayXML(object):
         else:
             handled = False
 
+        if handled:
+            self.mark_seen(tag)
+
         return handled
 
     def parse_day(self, xml_file, out):
@@ -1345,6 +1368,9 @@ class PBCParseDayXML(BaseParseDayXML):
         else:
             handled = super(PBCParseDayXML, self).handle_tag(tag_name, tag)
 
+        if handled:
+            self.mark_seen(tag)
+
         return handled
 
     def get_sitting(self, xml_file):
@@ -1626,6 +1652,9 @@ class LordsParseDayXML(BaseParseDayXML):
             self.parse_division(tag)
         else:
             handled = super(LordsParseDayXML, self).handle_tag(tag_name, tag)
+
+        if handled:
+            self.mark_seen(tag)
 
         return handled
 

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -1029,6 +1029,16 @@ class BaseParseDayXML(object):
         # make sure we add any outstanding speech.
         self.clear_current_speech()
 
+        all_IDS = set(
+            self.input_root[0].xpath(
+                './/@UID|.//@HRSContentId'
+                )
+        )
+        diff = all_IDS.difference(self.seen_elements)
+        if len(diff) > 0:
+            raise Exception(
+                'missed some elements', diff
+                )
         return True
 
     def get_date(self, xml_file):

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -1615,10 +1615,6 @@ class LordsParseDayXML(BaseParseDayXML):
             sys.stderr.write('newdebate with no heading', namespaces=self.ns_map)
             return
 
-        #procedure = tag.xpath('.//ns:hs_Procedure', namespaces=self.ns_map)
-        #if len(procedure) == 1:
-        #    self.handle_para(procedure[0])
-
         want_member = tag.get('BusinessType') in ('Question', 'GeneralDebate')
 
         member = None
@@ -1635,6 +1631,16 @@ class LordsParseDayXML(BaseParseDayXML):
         questions = tag.xpath('.//ns:hs_Question', namespaces=self.ns_map)
         for question in questions:
             self.parse_para_with_member(question, member if want_member else None)
+
+        # put in the rest of the headings as paragraphs at the start
+        heading = tag.xpath('.//ns:hs_DebateHeading | .//ns:hs_Procedure', namespaces=self.ns_map)
+        if len(heading) > 1:
+            for h in heading[1:]:
+                self.handle_tag('hs_para', h)
+
+        paras = tag.xpath('.//ns:hs_para', namespaces=self.ns_map)
+        for para in paras:
+            self.handle_tag('hs_para', para)
 
     def parse_amendment_heading(self, heading):
         self.new_speech(None, heading.get('url'))

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -885,6 +885,21 @@ class BaseParseDayXML(object):
                 continue
             self.parse_para(para)
 
+        # FIXME - we should actually store the numbers
+        england_tags = division.xpath('./ns:EnglandWales/ns:hs_Para/* | ./ns:England/ns:hs_Para/*', namespaces=self.ns_map)
+        if len(england_tags):
+            self.mark_xpath_all_seen(division, './ns:EnglandWales | ./ns:England')
+            self.mark_xpath_all_seen(division, './ns:EnglandWales/ns:hs_Para | ./ns:England/ns:hs_Para')
+            details = etree.Element('p')
+            text = ''
+            for england_tag in england_tags:
+                self.mark_seen(england_tag)
+                content = tag.text
+                if content:
+                    text += content
+            details.text = text
+            self.current_speech.append(details)
+
     def parse_time(self, tag):
         self.mark_seen(tag)
         time_txt = u''.join(tag.xpath('.//text()'))

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -766,18 +766,23 @@ class BaseParseDayXML(object):
         return vote_list
 
     def parse_table(self, wrapper):
-        rows = wrapper.xpath('.//row')
+        rows = wrapper.xpath('.//ns:row', namespaces=self.ns_map)
         tag = etree.Element('table')
         body = etree.Element('tbody')
         url = None
         for row in rows:
+            self.mark_seen(row)
             row_tag = etree.Element('tr')
             row_tag.set('pid', self.get_pid())
 
-            for entry in row.xpath('(.//hs_brev|.//hs_Para)'):
-                if url is None:
-                    url = entry.get('url')
-                row_tag.append(list(entry))
+            for entry in row.xpath('.//ns:entry', namespaces=self.ns_map):
+                cell_tag = etree.Element('td')
+                cell_tag.text = self.get_single_line_text_from_element(entry)
+                row_tag.append(cell_tag)
+                for para in entry.xpath('.//ns:hs_Para | .//ns:hs_para | .//ns:hs_brev', namespaces=self.ns_map):
+                    if url is None:
+                        url = para.get('url')
+                    self.mark_seen(para)
 
             body.append(row_tag)
 

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -882,6 +882,14 @@ class BaseParseDayXML(object):
             if re.search(r'House\s*divided', text) or \
                     re.search(r'Committee\s*divided', text) or \
                     re.search(r'Division\s*No', text):
+                self.mark_seen(para)
+                for tag in para:
+                    tag_name = self.get_tag_name_no_ns(tag)
+                    if tag_name == 'Right':
+                        times = tag.xpath('.//ns:Time', namespaces=self.ns_map)
+                        if len(times) > 0:
+                            self.parse_time(times[0])
+                    self.mark_seen(tag)
                 continue
             self.parse_para(para)
 

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -141,7 +141,6 @@ class BaseParseDayXML(object):
         'hs_AmendmentLevel2',
         'hs_AmendmentLevel3',
         'hs_AmendmentLevel4',
-        'hs_8Clause',
         'hs_newline10',
         'hs_Question',
         'hs_6CntrCapsHdg',
@@ -160,6 +159,7 @@ class BaseParseDayXML(object):
         'hs_TimeCode',
         'hs_6bPetitions',
         'hs_3MainHdg',
+        'hs_8Clause',
         'hs_Venue'
     ]
     root = None
@@ -483,6 +483,23 @@ class BaseParseDayXML(object):
         tag.text = text
         self.root.append(tag)
         self.output_heading = True
+
+        # if there is a clause immediately before then assume it's the clause
+        # we are about to debate and put it in the first speech
+        previous = heading.xpath(
+            './preceding-sibling::*',
+            namespaces=self.ns_map
+        )
+        if len(previous):
+            clause = previous[-1]
+            if self.get_tag_name_no_ns(clause) == 'hs_8Clause':
+                self.mark_seen(clause)
+                text = self.get_single_line_text_from_element(clause)
+                if self.current_speech is None:
+                    self.new_speech(None, clause.get('url'))
+                clause_tag = etree.Element('p')
+                clause_tag.text = text
+                self.current_speech.append(clause_tag)
 
     def parse_generic(self, heading):
         if self.next_speech_num == 0:
@@ -1189,6 +1206,7 @@ class PBCParseDayXML(BaseParseDayXML):
     ignored_tags = [
         'hs_CLHeading',
         'hs_CLAttended',
+        'hs_8Clause',
         'hs_6fCntrItalHdg',
     ]
 

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -1656,12 +1656,17 @@ class LordsParseDayXML(BaseParseDayXML):
         )
 
     def parse_amendment(self, amendment):
-        self.parse_para_with_member(
-            amendment,
-            None,
-            css_class='italic',
-            pwmotiontext='unrecognized'
-        )
+        # Amendments are often things like:
+        #
+        # <Amendment><hs_quote><B>54:</B>
+        # Clause 67, page 30, line 9, leave out “high” and insert
+        # “higher”</hs_quote></Amendment>
+        #
+        # so we need to parse the tags to make sure we get the
+        # indenting etc
+        for tag in amendment.getchildren():
+            tag_name = self.get_tag_name_no_ns(tag)
+            self.handle_tag(tag_name, tag)
 
     def parse_clause_heading(self, heading):
         tag = etree.Element('p')

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -617,6 +617,15 @@ class BaseParseDayXML(object):
 
         p.text = re.sub('\n', ' ', text)
         tag.append(p)
+
+        if len(para) > 1:
+            for p in para:
+                text = self.get_single_line_text_from_element(p)
+                if text != '':
+                    p = etree.Element('p')
+                    p.text = re.sub('\n', ' ', text)
+                    tag.append(p)
+
         self.root.append(tag)
 
     def parse_indent(self, tag):

--- a/pyscraper/reparse.py
+++ b/pyscraper/reparse.py
@@ -1,0 +1,97 @@
+#! /usr/bin/env python
+
+import argparse
+import os
+import re
+from os.path import join
+
+from miscfuncs import toppath
+from new_hansard import ParseDay
+
+index_filename = join(toppath, 'seen_hansard_xml.txt')
+reparse_filename = join(toppath, 'reparse_hansard_xml.txt')
+zip_directory = join(toppath, 'cmpages', 'hansardzips')
+zip_dir_slash = "%s/" % zip_directory
+line_re = re.compile(r'^[^:]*:(.*/)([^/]*)$')
+files = {}
+
+parser = argparse.ArgumentParser(description='Process Hansard XML.')
+parser.add_argument('-v', '--verbose', action='count')
+ARGS = parser.parse_args()
+
+# make sure we only look at a file once
+class Entries(list):
+    def __init__(self):
+        entries = []
+        if os.path.exists(reparse_filename):
+            with open(reparse_filename) as f:
+                entries = [e.strip().replace(zip_dir_slash, '') for e in f.readlines()]
+        super(Entries, self).__init__(entries)
+
+    def dump(self):
+        with open(reparse_filename, 'w') as f:
+            f.writelines("{0}\n".format(entry) for entry in self)
+
+entries = Entries()
+
+
+def handle_file(filename, debate_type):
+    file_key = '{0}:{1}'.format(
+        debate_type,
+        filename.strip().replace(zip_dir_slash, '')
+    )
+    if file_key in entries:
+        if ARGS.verbose:
+            print "already seen {0}, not re-parsing again".format(filename)
+        return False
+
+    parser.reset()
+    if ARGS.verbose:
+        print "looking at {0}".format(filename)
+    ret = parser.handle_file(filename, debate_type, ARGS.verbose)
+
+    if ret == 'failed':
+        print "ERROR parsing {0} {1}".format(filename, debate_type)
+    elif ret == 'not-present':
+        print "Nothing to parse in {0} {1}".format(filename, debate_type)
+    elif ret == 'same':
+        print "parsed {0} {1}, no changes from {2}".format(
+            filename, debate_type, parser.prev_file
+        )
+    elif ret in ('change', 'new'):
+        print "parsed {0} {1} to {2}".format(
+            filename, debate_type, parser.output_file
+        )
+    else:
+        print "parsed {0} {1} to {2}, unknown return {3}".format(
+            filename, debate_type, parser.output_file, ret
+        )
+    entries.append(file_key)
+
+    return True
+
+with open(index_filename) as lines:
+    for line in lines:
+        matches = line_re.search(line.strip())
+        if matches:
+            files[matches.group(2)] = matches.group(1) + matches.group(2)
+
+parser = ParseDay()
+
+try:
+    for filename in files.values():
+        f = join(toppath, 'cmpages', 'hansardzips', filename)
+        if 'CHAN' in f:
+            handle_file(f, 'debate')
+            handle_file(f, 'westminhall')
+        elif 'LHAN' in f:
+            handle_file(f, 'lords')
+        elif 'PBC' in f:
+            handle_file(f, 'standing')
+
+# this is just to make sure we record progress
+except Exception:
+    entries.dump()
+    raise
+
+entries.dump()


### PR DESCRIPTION
The parser now tracks all the tags it sees as it goes using tag IDs and then compares those to a list of IDs extracted using XPath. If there is a difference between the lists it throws an Exception.

There's also a number of parser improvements in here which were found in the process of making sure that it parsed things correctly:

* Fix for the parser failing to pick up all the text if there is more than one hs_Para element inside a Question tag
* Fixes broken table parsing code
* Fixes missing some content inside division tags
* Correctly handles clause tags to be part of the immediately following Amendment
* Makes hs_2cDebatedMotion a major heading
* Fixes missing some content inside new debate tags.

It also adds a script to make re-parsing easier.

Fixes #54
Fixes #66