### PR TITLE
Links to data.mysociety.org

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,16 +14,16 @@
             <div class="col-sm-4">
                 <nav class="mysoc-footer__links">
                     <ul>
-                        <li role="presentation"><a href="http://www.theyworkforyou.com">TheyWorkForYou</a></li>
+                        <li role="presentation"><a href="https://www.theyworkforyou.com">TheyWorkForYou</a></li>
                         <li role="presentation"><a href="http://www.publicwhip.org.uk/">Public Whip</a></li>
-                        <li role="presentation"><a href="http://www.theyworkforyou.com/api/">TheyWorkForYou API</a></li>
+                        <li role="presentation"><a href="https://www.theyworkforyou.com/api/">TheyWorkForYou API</a></li>
                         <li role="presentation"><a href="https://www.mysociety.org/democracy/">mySociety Democracy</a></li>
                     </ul>
                     <ul>
                         <li role="presentation"><a href="https://data.mysociety.org">Data &amp; APIs</a></li>
                         <li role="presentation"><a href="https://groups.google.com/a/mysociety.org/forum/#!forum/theyworkforyou">Mailing list</a></li>
                         <li role="presentation"><a href="https://github.com/mysociety/parlparse">GitHub</a></li>
-                        <li role="presentation"><a href="http://www.irc.mysociety.org/">IRC</a></li>
+                        <li role="presentation"><a href="https://www.irc.mysociety.org/">IRC</a></li>
                     </ul>
                 </nav>
             </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,6 +20,7 @@
                         <li role="presentation"><a href="https://www.mysociety.org/democracy/">mySociety Democracy</a></li>
                     </ul>
                     <ul>
+                        <li role="presentation"><a href="https://data.mysociety.org">Data &amp; APIs</a></li>
                         <li role="presentation"><a href="https://groups.google.com/a/mysociety.org/forum/#!forum/theyworkforyou">Mailing list</a></li>
                         <li role="presentation"><a href="https://github.com/mysociety/parlparse">GitHub</a></li>
                         <li role="presentation"><a href="http://www.irc.mysociety.org/">IRC</a></li>

--- a/assets/css/global.min.scss
+++ b/assets/css/global.min.scss
@@ -6,3 +6,12 @@
 // Imports are relative to _sass directory
 @import 'config';
 @import '../theme/sass/global';
+
+
+@media (min-width: $mysoc-footer-breakpoint-sm){
+  .mysoc-footer__links {
+    ul {
+      width: auto;
+    }
+  }
+}

--- a/index.md
+++ b/index.md
@@ -6,11 +6,16 @@ title: Overview
 ## What can I find here?
 
 Structured versions of publicly available data from the UK parliament, and the
-source code that was used to generate the data. This is the engine of clever
-stuff which runs <a href="http://www.theyworkforyou.com">TheyWorkForYou.com</a>
-and <a href="http://www.publicwhip.org.uk">The Public Whip</a>. You might find
-the <a href="http://www.theyworkforyou.com/api">TheyWorkForYou API</a> easier to
-use.
+source code that was used to generate the data.
+
+This is the engine of clever stuff which runs
+<a href="http://www.theyworkforyou.com">TheyWorkForYou.com</a> and
+<a href="http://www.publicwhip.org.uk">The Public Whip</a>. You might find
+the <a href="http://www.theyworkforyou.com/api">TheyWorkForYou API</a>
+easier to use.
+
+APIs and datasets for other mySociety services can be found on our data
+portal, <a href="http://data.mysociety.org">data.mysociety.org</a>.
 
 ## Who can I talk to about it?
 


### PR DESCRIPTION
Part of https://github.com/mysociety/jkan/issues/6.

If people are interested in Parlparse data, they might also be interested in the other datasets available at https://data.mysociety.org.

While I was messing around with the footer links, I noticed that resetting the `width: 50%` on the two lists back to `width: auto` would prevent "TheyWorkForYou API" from breaking onto two lines, hence the little CSS change in 30224fc.

@dracos Are you happy with these changes?