### PR TITLE
Add start/end reasons to London Assembly memberships

### DIFF
--- a/scripts/fetch_london_assembly.py
+++ b/scripts/fetch_london_assembly.py
@@ -48,7 +48,8 @@ WD_PARTY_CHANGE_OBJECT = 'Q30580660'
 
 # Unlike start reasons, end reasons are generally explicit.
 END_REASON_MAP = {
-    WD_PARTY_CHANGE_OBJECT: 'changed_party'
+    WD_PARTY_CHANGE_OBJECT: 'changed_party',
+    'Q63323711': 'regional_election'  # This is a generic 'end of legislative term' object
 }
 
 logger = logging.getLogger('import-members-from-wikidata')


### PR DESCRIPTION
Adds `start_reason` and `end_reason` data to memberships from London Assembly.

For `start_reason`, defaults to `unknown`, except for if:

1. The membership has an "elected in" property, in which case `start_reason` is `regional_election`, or;
2. For memberships where the person has previously ended a membership with `changed_party`, if the end date of that membership matches the start date of this one, assume the start reason is also `changed_party`.

For `end_reason`, will default to `unknown` but will raise a warning whilst doing so (this should usually be provided explicitly in Wikidata). Mappings between Wikidata IDs and ParlParse reason codes are in the `END_REASON_MAP` hash.