### PR TITLE
Update Python requests package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ egenix-mx-base==3.2.9
 everypolitician==0.0.13
 lxml==3.4.0
 python-dateutil==2.2
-requests[security]==2.4.3
+requests[security]==2.21.0
 requests-cache==0.4.13


### PR DESCRIPTION
This updates the `requests` python package to the current release. A more recent version is needed when building against versions of OpenSSL without SSLv3 support, so we may as well bump to the current stable version.