### PR TITLE
Written questions/statements, and table fixes

### DIFF
--- a/pyscraper/gidmatching.py
+++ b/pyscraper/gidmatching.py
@@ -46,8 +46,8 @@ def PrepareXMLForDiff(scrapeversion):
 		assert chk[0] == chk[3]  # chunk type (this can fail if due to the lack of two \n's between the two labels, and thus detects an empty speech, which should not be there.  
 		# new_chk = chk[2]
 		new_chk = re.sub(
-			'(?s)(<p\s[^>]*>)(.*?)(<\/p>)',
-			lambda m: (u''.join((m.group(1), re.sub('\n', ' ', m.group(2)), m.group(3)))),
+			r'(?s)(<(p|tr)\s[^>]*>)(.*?)(<\/\2>)',
+			lambda m: (u''.join((m.group(1), re.sub('\n', ' ', m.group(3)), m.group(4)))),
 			chk[2]
 		)
 		essxindx.append(len(essxlist))

--- a/pyscraper/new_hansard.py
+++ b/pyscraper/new_hansard.py
@@ -763,7 +763,7 @@ class BaseParseDayXML(object):
         return vote_list
 
     def parse_table(self, wrapper):
-        rows = wrapper.xpath('.//row')
+        rows = wrapper.xpath('.//ns:row', namespaces=self.ns_map)
         tag = etree.Element('table')
         body = etree.Element('tbody')
         url = None
@@ -771,12 +771,15 @@ class BaseParseDayXML(object):
             row_tag = etree.Element('tr')
             row_tag.set('pid', self.get_pid())
 
-            for entry in row.xpath('(.//hs_brev|.//hs_Para)'):
+            for entry in row.xpath('(.//ns:hs_brev|.//ns:hs_Para)', namespaces=self.ns_map):
                 if url is None:
                     url = entry.get('url')
-                row_tag.append(list(entry))
+                td_tag = etree.Element('td')
+                td_tag.text = self.get_single_line_text_from_element(entry)
+                row_tag.append(td_tag)
 
-            body.append(row_tag)
+            if len(row_tag):
+                body.append(row_tag)
 
         tag.append(body)
 


### PR DESCRIPTION
Parliament launched a whole new site at https://questions-statements.parliament.uk/ - this updates the code to fetch data from there. They do have an API but this morning it was over a day behind the site. This appears to be okay now, but we don't know whether the API is maintained as well as the site, so we shall stick with fetching directly from the site for now (one downside is the API does tell you if questions are grouped which the website does not any more, but that's not major).

Also fix an issue whereby we weren't parsing tables in Hansard - spotting the table but then ignoring all its rows.