### PR TITLE
Update social-media-commons.xml

### DIFF
--- a/members/social-media-commons.xml
+++ b/members/social-media-commons.xml
@@ -140,7 +140,7 @@
   <personinfo facebook_page="https://facebook.com/ChristopherPincher" id="uk.org.publicwhip/person/24747" twitter_username="ChrisPincher"/>
   <personinfo facebook_page="https://facebook.com/ChukaUmunnaMP" id="uk.org.publicwhip/person/24950" twitter_username="ChukaUmunna"/>
   <personinfo facebook_page="https://facebook.com/claire4devizes" id="uk.org.publicwhip/person/24915" twitter_username="claire4devizes"/>
-  <personinfo facebook_page="https://facebook.com/clive.betts.sheffieldse" id="uk.org.publicwhip/person/10045" twitter_username="CliveBettsMP"/>
+  <personinfo facebook_page="https://facebook.com/clive.betts.sheffieldse" id="uk.org.publicwhip/person/10045"/>
   <personinfo facebook_page="https://facebook.com/clive.efford" id="uk.org.publicwhip/person/10185" twitter_username="CliveEfford"/>
   <personinfo facebook_page="https://facebook.com/labourclivelewis" id="uk.org.publicwhip/person/25356" twitter_username="labourlewis"/>
   <personinfo facebook_page="https://facebook.com/ColinClarkMP" id="uk.org.publicwhip/person/25678" twitter_username="Colin_J_Clark"/>


### PR DESCRIPTION
Removed Clive Betts' Twitter account, as it no longer exists