### PR TITLE
New Scottish Parliament Scraper

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,25 @@
+name: Push mirror to git.mysociety.org
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: '0'
+
+    - name: Push branch to git.mysociety.org
+      id: push_to_mirror
+      uses: mysociety/action-git-pusher@v1.1.1
+      with:
+        git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
+        ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
+        tag: ${{ github.ref_name }} 
+        remote: 'ssh://gh-public@git.mysociety.org/data/git/public/parlparse.git'

--- a/pyscraper/sp/common.py
+++ b/pyscraper/sp/common.py
@@ -10,42 +10,6 @@ from bs4 import Comment
 
 import re
 
-# A number of SPIDs have a 0 (zero) in place of an O (letter O), and
-# this converts a string containing them.  It also fixes leading 0s in
-# the number after the hyphen.
-def fix_spid(s):
-    result = re.sub('(S[0-9]+)0-([0-9]+)',r'\1O-\2',s)
-    return re.sub('(S[0-9]+\w+)-0*([0-9]+)',r'\1-\2',result)
-
-months = { "january"   : 1,
-           "february"  : 2,
-           "march"     : 3,
-           "april"     : 4,
-           "may"       : 5,
-           "june"      : 6,
-           "july"      : 7,
-           "august"    : 8,
-           "september" : 9,
-           "october"   : 10,             
-           "november"  : 11,
-           "december"  : 12 }
-
-abbreviated_months = { }
-for k in months.keys():
-    abbreviated_months[k[0:3]] = months[k]
-
-def month_name_to_int( name ):
-
-    lowered = name.lower()
-
-    if lowered in months:
-        return months[lowered]
-
-    if lowered in abbreviated_months:
-        return abbreviated_months[lowered]
-
-    return 0
-
 def non_tag_data_in(o, tag_replacement=''):
     if o.__class__ == NavigableString:
         return re.sub('(?ms)[\r\n]',' ',o)
@@ -66,49 +30,6 @@ def tidy_string(s):
     result = re.sub("(?imsu)^\s*:\s*",'',s)
     result = re.sub('(?ims)\s+',' ',result)
     return result.strip()
-
-# These two methods from:
-#
-#  http://snippets.dzone.com/posts/show/4569
-
-from html.entities import name2codepoint
-
-def substitute_entity(match):
-    ent = match.group(2)
-    if match.group(1) == "#":
-        return chr(int(ent))
-    else:
-        cp = name2codepoint.get(ent)
-        if cp:
-            return chr(cp)
-        else:
-            return match.group()
-
-def decode_htmlentities(string):
-    entity_re = re.compile("&(#?)(\d{1,5}|\w{1,8});")
-    return entity_re.subn(substitute_entity, string)[0]
-
-def compare_spids(a,b):
-    ma = re.search('S(\d+\w+)-(\d+)',a)
-    mb = re.search('S(\d+\w+)-(\d+)',b)
-    if ma and mb:
-        mas = ma.group(1)
-        mbs = mb.group(1)
-        mai = int(ma.group(2),10)
-        mbi = int(mb.group(2),10)
-        if mas < mbs:
-            return -1
-        elif mas > mbs:
-            return 1
-        else:
-            if mai < mbi:
-                return -1
-            if mai > mbi:
-                return 1
-            else:
-                return 0
-    else:
-        raise Exception("Couldn't match spids: "+a+" and "+b)
 
 def just_time( non_tag_text ):
     m = re.match( '^\s*(\d?\d)[:\.](\d\d)\s*$', non_tag_text )

--- a/pyscraper/sp_2024/__main__.py
+++ b/pyscraper/sp_2024/__main__.py
@@ -1,0 +1,111 @@
+"""
+Cli for scraping Scottish Parliament 2024
+
+Use `python -m pyscraper.sp_2024 --help` to see available commands
+"""
+
+from __future__ import annotations
+
+from .download import fetch_debates_for_dates
+from .parse import tidy_up_html
+from .convert import convert_xml_to_twfy
+import click
+from pathlib import Path
+import datetime
+
+file_dir = Path(__file__).parent
+parldata = Path(file_dir, "..", "..", "..", "parldata")
+
+cache_dir = parldata / "cmpages" / "sp_2024"
+output_dir = parldata / "scrapedxml" / "sp_2024"
+
+
+@click.group()
+def cli():
+    pass
+
+
+def cache_dir_iterator(
+    cache_dir: Path,
+    start_date: datetime.date,
+    end_date: datetime.date,
+):
+    """
+    Return an iterator of files in the cache_dir that are between the start and end date
+    """
+
+    for file in cache_dir.glob("*.xml"):
+        # date is an iso date at the start of the filename
+        date = datetime.date.fromisoformat(file.stem[:10])
+        if start_date <= date <= end_date:
+            yield file
+
+
+@cli.command()
+@click.option(
+    "--start-date", help="isodate to start fetching debates from", required=True
+)
+@click.option("--end-date", help="isodate to end fetching debates at", required=True)
+@click.option(
+    "--download",
+    is_flag=True,
+    help="Download the debates, pair with 'override' to redownload all files",
+)
+@click.option("--parse", is_flag=True, help="Parse the downloaded debates")
+@click.option("--convert", is_flag=True, help="Convert the parsed debates")
+@click.option("--verbose", is_flag=True, help="Print verbose output")
+@click.option("--override", is_flag=True, help="Override existing files")
+@click.option(
+    "--partial-file-name", help="Only parse/convert files that match this string"
+)
+def debates(
+    start_date: str,
+    end_date: str,
+    download: bool = False,
+    parse: bool = False,
+    convert: bool = False,
+    verbose: bool = False,
+    override: bool = False,
+    partial_file_name: str | None = None,
+):
+    """
+    Download transcripts from Scottish Parliament between a start and end date.
+    """
+
+    start = datetime.date.fromisoformat(start_date)
+    end = datetime.date.fromisoformat(end_date)
+
+    # if none of the flags are set, error that at least one flag must be set
+    if not any([download, parse, convert]):
+        click.echo("At least one of the flags must be set")
+        return
+
+    # iterate through downloaded files if we're downloading them
+    # otherwise go find the relevant files based on name
+    if download:
+        file_iterator = fetch_debates_for_dates(
+            start.isoformat(),
+            end.isoformat(),
+            verbose=verbose,
+            cache_dir=cache_dir,
+            override=override,
+        )
+    else:
+        file_iterator = cache_dir_iterator(cache_dir, start, end)
+
+    for file in file_iterator:
+        if partial_file_name:
+            if not file.name.startswith(partial_file_name):
+                continue
+        if parse:
+            if verbose:
+                print(f"Parsing up {file}")
+            tidy_up_html(file)
+        if convert:
+            if verbose:
+                print(f"Converting {file} to TheyWorkForYou format")
+            convert_xml_to_twfy(file, output_dir, verbose=verbose)
+
+
+if __name__ == "__main__":
+    cli(prog_name="python -m pyscraper.sp_2024")

--- a/pyscraper/sp_2024/common.py
+++ b/pyscraper/sp_2024/common.py
@@ -1,0 +1,71 @@
+# A few functions that turn out to be useful in many of the Scottish
+# Parliament scraping scripts.
+
+import sys
+import datetime
+
+sys.path.append("../")
+from bs4 import NavigableString
+from bs4 import Tag
+from bs4 import Comment
+
+import re
+
+
+def non_tag_data_in(o, tag_replacement=""):
+    if o.__class__ == NavigableString:
+        return re.sub("(?ms)[\r\n]", " ", o)
+    elif o.__class__ == Tag:
+        if o.name == "script":
+            return tag_replacement
+        else:
+            return tag_replacement.join([non_tag_data_in(x) for x in o.contents])
+    elif o.__class__ == Comment:
+        return tag_replacement
+    else:
+        # Hope it's a string or something else concatenatable...
+        return o
+
+
+def tidy_string(s):
+    # Lots of the paragraphs in the HTML begin with a pointless ':'
+    # surrounded by spaces:
+    result = re.sub("(?imsu)^\s*:\s*", "", s)
+    result = re.sub("(?ims)\s+", " ", result)
+    return result.strip()
+
+
+def just_time(non_tag_text):
+    m = re.match("^\s*(\d?\d)[:\.](\d\d)\s*$", non_tag_text)
+    if m:
+        return datetime.time(int(m.group(1), 10), int(m.group(2), 10))
+    else:
+        return None
+
+
+def meeting_closed(non_tag_text):
+    m = re.match(
+        "(?imsu)^\s*:?\s*Meeting\s+closed\s+at\s+(\d?\d)[:\.](\d\d)\s*\.?\s*$",
+        non_tag_text,
+    )
+    if m:
+        return datetime.time(int(m.group(1), 10), int(m.group(2), 10))
+    else:
+        return None
+
+
+def meeting_suspended(non_tag_text):
+    m = re.match(
+        "(?imsu)^\s*:?\s*Meeting\s+suspended(\s+(at|until)\s+(\d?\d)[:\.](\d\d)\s*\.?\s*|\s*\.?\s*)$",
+        non_tag_text,
+    )
+    if m:
+        if m.group(2):
+            at_or_until = m.group(2)
+            hours = m.group(3)
+            minutes = m.group(4)
+            return (True, at_or_until, datetime.time(int(hours, 10), int(minutes, 10)))
+        else:
+            return (True, None, None)
+    else:
+        return None

--- a/pyscraper/sp_2024/convert.py
+++ b/pyscraper/sp_2024/convert.py
@@ -1,0 +1,207 @@
+"""
+Convert the structured data from Scottish Parliament to
+the XML format used by TheyWorkForYou
+
+Link to TWFY IDs for members and debate items.
+"""
+
+import datetime
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from lxml import etree
+
+from .resolvenames import get_unique_person_id, is_member_vote
+
+
+def slugify(text: str) -> str:
+    """
+    Convert a string to a url safe slug
+    """
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text).replace(" ", "-")
+
+    return text
+
+
+@dataclass
+class IDFactory:
+    committee_slug: str
+    iso_date: str
+    base_id: str = "uk.org.publicwhip/spor/"
+    latest_major: int = -1
+    latest_minor: int = -1
+
+    def _current_id(self) -> str:
+        return f"{self.base_id}{self.committee_slug}/{self.iso_date}.{self.latest_major}.{self.latest_minor}"
+
+    def get_next_major_id(self) -> str:
+        self.latest_major += 1
+        self.latest_minor = 0
+        return self._current_id()
+
+    def get_next_minor_id(self) -> str:
+        self.latest_minor += 1
+        return self._current_id()
+
+
+def slugify_committee(name: str) -> str:
+    """
+    Convert a committee name to a slug
+    """
+    name = slugify(name)
+    # if this ends in a year (four digita number) - assume it's a date and remove the last three elements
+    if name[-4:].isdigit():
+        name = "-".join(name.split("-")[:-3])
+
+    return name
+
+
+def convert_xml_to_twfy(file_path: Path, output_dir: Path, verbose: bool = False):
+    """
+    Convert from the loose structured xml format to the
+    TWFY xml format
+    """
+    if verbose:
+        print(f"Converting {file_path}")
+
+    # get source as an xml tree
+    with file_path.open("r") as f:
+        source = etree.fromstring(f.read())
+
+    # root of the tree is a publicwhip object
+    root = etree.Element("publicwhip")
+
+    url = source.get("url")
+    title = source.get("title")
+    iso_date = source.get("date")
+    source_id = int(float(source.get("id")[1:]))
+    timestamp = ""
+
+    # remove [Draft] from title
+    title = title.replace("[Draft]", "").strip()
+
+    # get the date in format Thursday 9 June 2005
+    date_str = datetime.date.fromisoformat(iso_date).strftime("%A %d %B %Y")
+
+    committee_slug = slugify_committee(title)
+
+    dest_path = output_dir / committee_slug / f"{iso_date}_{source_id}.xml"
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    id_factory = IDFactory(committee_slug=committee_slug, iso_date=iso_date)
+
+    # iterate through the agenda_items
+    for item in source.iter("agenda_item"):
+        # create a new major-heading from the agenda_item information
+        major_heading = etree.Element("major-heading")
+        major_heading.set("id", id_factory.get_next_major_id())
+        major_heading.set("url", item.get("url"))
+        major_heading.set("nospeaker", "True")
+        major_heading.text = item.get("title")
+        root.append(major_heading)
+
+        # iterate through the agenda_item's subitems
+        # if item is a speech or a division, get the new informaton and bring across
+        previous_speech = None
+        missing_speakers = []
+        for subitem in item.find("parsed"):
+            if subitem.tag == "speech":
+                speaker_name = subitem.get("speaker_name")
+                scot_parl_id = subitem.get("speaker_scot_id")
+                person_id = get_unique_person_id(
+                    speaker_name, iso_date, lookup_key=scot_parl_id
+                )
+                if (
+                    person_id is None
+                    and speaker_name not in missing_speakers
+                    and verbose
+                ):
+                    print(f"Could not find person id for {speaker_name}")
+                    missing_speakers.append(speaker_name)
+                speech = etree.Element("speech")
+                speech.set("id", id_factory.get_next_minor_id())
+                speech.set("url", subitem.get("speech_url") or "")
+                speech.set("speakername", speaker_name)
+                if timestamp:
+                    speech.set("time", timestamp)
+                speech.set("person_id", person_id or "unknown")
+                for child in subitem:
+                    speech.append(child)
+                root.append(speech)
+                previous_speech = speech
+
+            elif subitem.tag == "timestamp":
+                if m := re.match("\s*(\d\d:\d\d)(.*)", subitem.text):
+                    timestamp = m.group(1)
+                    text = m.group(2)
+                else:
+                    text = subitem.text
+                text = text.replace("\xa0", " ").strip()
+                if text:
+                    p = etree.Element("p")
+                    p.set("class", "italic")
+                    p.text = text
+                    speech = etree.Element("speech")
+                    speech.set("id", id_factory.get_next_minor_id())
+                    speech.set("url", subitem.get("speech_url") or "")
+                    if timestamp:
+                        speech.set("time", timestamp)
+                    speech.append(p)
+                    root.append(speech)
+
+            elif subitem.tag == "heading":
+                minor_heading = etree.Element("minor-heading")
+                minor_heading.set("id", id_factory.get_next_minor_id())
+                minor_heading.set("url", item.get("url"))
+                minor_heading.text = subitem.text
+                root.append(minor_heading)
+
+            elif subitem.tag == "division":
+                # get previous sibling of the subitem to get the speech info
+
+                if previous_speech is None:
+                    raise ValueError("Division without a previous speech")
+
+                division = etree.Element("division")
+                division.set("id", id_factory.get_next_minor_id())
+                division.set("url", previous_speech.get("url"))
+                division.set("divdate", iso_date)
+                division.set("divnumber", subitem.get("divnum"))
+                division.set("nospeaker", "True")
+                for child in subitem:
+                    division.append(child)
+                root.append(division)
+
+    # for all mspnames elements, we need to create an ID property
+    for mspname in root.iter("mspname"):
+        person_name = mspname.text
+        person_id = is_member_vote(person_name, iso_date)
+        if person_id is None:
+            print(f"Could not find person id for {person_name}")
+        mspname.set("id", person_id or "unknown")
+
+    # write the new xml to a file
+    etree.indent(root, space="    ")
+
+    with dest_path.open("wb") as f:
+        f.write(etree.tostring(root, pretty_print=True))
+
+
+def convert_to_twfy(
+    cache_dir: Path,
+    output_dir: Path,
+    partial_file_name: str | None = None,
+    verbose: bool = False,
+):
+    """
+    Given a cache directory, parse the raw_html elements in the xml files
+    This updates the 'parsed' element under each agenda-item.
+    """
+    if partial_file_name:
+        xmls = list(cache_dir.glob(f"{partial_file_name}*"))
+    else:
+        xmls = list(cache_dir.glob("*.xml"))
+    for xml in xmls:
+        convert_xml_to_twfy(xml, output_dir, verbose=verbose)

--- a/pyscraper/sp_2024/download.py
+++ b/pyscraper/sp_2024/download.py
@@ -1,0 +1,234 @@
+"""
+Module for downloading the debates from the Scottish Parliament website.
+
+This uses the search page to get a list of committees that have met on a given date or range.
+Individual agenda items are then queried and dumped in an XML file in the cache directory.
+One file per committee per day.
+
+"""
+
+from __future__ import annotations
+
+from itertools import groupby
+from pathlib import Path
+from typing import Iterator, NamedTuple
+from urllib.parse import parse_qs, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from lxml import etree
+
+user_agent = (
+    "Mozilla/5.0 (Ubuntu; X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1"
+)
+
+scot_prefix = "https://www.parliament.scot"
+search_url = "/chamber-and-committees/official-report/search-what-was-said-in-parliament?msp=&committeeSelect=&qry=&dateSelect=custom&dtDateFrom={start_date}&dtDateTo={end_date}&showPlenary=true&ShowDebates=true&ShowFMQs=true&ShowGeneralQuestions=true&ShowPortfolioQuestions=true&ShowSPCBQuestions=true&ShowTopicalQuestions=true&ShowUrgentQuestions=true&showCommittee=true&page={page}"
+item_url = "/chamber-and-committees/official-report/search-what-was-said-in-parliament/{slug}?meeting={id}&iob={iob}"
+major_heading_url = "/chamber-and-committees/official-report/search-what-was-said-in-parliament/{slug}?meeting={id}"
+
+
+def get_meeting_urls(start_date: str, end_date: str, page: int = 1):
+    """
+    Query the Scottish Parliament search page for a given date range to get all links for agenda meetings
+    """
+    date_url = scot_prefix + search_url.format(
+        start_date=start_date, end_date=end_date, page=page
+    )
+    response = requests.get(date_url, headers={"User-Agent": user_agent})
+
+    # extract all urls that contain /search-what-was-said-in-parliament/
+    soup = BeautifulSoup(response.text, "html.parser")
+    meeting_urls = [
+        a["href"]
+        for a in soup.find_all("a", href=True)
+        if "/search-what-was-said-in-parliament/" in a["href"]
+    ]
+
+    # section headings
+    heading_urls = [url for url in meeting_urls if "&iob=" not in url]
+    heading_count = len(set(heading_urls))
+
+    # discard any without a iob parameter
+    meeting_urls = [url for url in meeting_urls if "&iob=" in url]
+
+    # remove duplicates
+    meeting_urls = sorted(list(set(meeting_urls)))
+    return heading_count, meeting_urls
+
+
+def get_debate_groupings(start_date: str, end_date: str) -> list[DebateGrouping]:
+    """
+    Query the search page and get the urls for the meetings in that date range
+    """
+
+    keep_fetching = True
+    search_page = 1
+    meeting_urls = []
+
+    while keep_fetching:
+        heading_count, page_result_urls = get_meeting_urls(
+            start_date, end_date, search_page
+        )
+        meeting_urls.extend(page_result_urls)
+        if heading_count < 10:
+            keep_fetching = False
+        else:
+            search_page += 1
+
+    def get_committee_slug(url: str):
+        return url.split("?")[0].split("/")[-1]
+
+    groupings = []
+
+    for g, items in groupby(meeting_urls, key=get_committee_slug):
+        date = "-".join(reversed(g.split("-")[-3:]))
+        url_ids = []
+        url_iobs = []
+
+        for item in items:
+            # get the url parameters as dict
+            parsed = parse_qs(urlparse(item).query)
+            url_ids.append(int(parsed["meeting"][0]))
+            url_iobs.append(int(parsed["iob"][0]))
+
+        if len(set(url_ids)) > 1:
+            raise ValueError("Multiple committee ids in grouping")
+
+        groupings.append(
+            DebateGrouping(
+                date=date,
+                committee_date_slug=g,
+                committee_date_id=url_ids[0],
+                items=url_iobs,
+            )
+        )
+
+    return groupings
+
+
+class DebateGrouping(NamedTuple):
+    date: str
+    committee_date_slug: str
+    committee_date_id: int
+    items: list[int]
+
+    def urls(self) -> Iterator[str]:
+        """
+        Generator for the urls of the agenda items
+        """
+        for i in self.items:
+            yield scot_prefix + item_url.format(
+                slug=self.committee_date_slug, id=self.committee_date_id, iob=i
+            )
+
+    def get_debate_item_content(self, speech_id: str, url: str):
+        """
+        For each agenda item (they're on separate pages)
+        Query the page, extract the header name and agenda item, and then
+        the contents of the actual debate.
+        We just save that to parse it later.
+        """
+
+        response = requests.get(url, headers={"User-Agent": user_agent})
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # first h1 is the heading, last h2 is the subheading
+        heading = soup.find_all("h1")[0].text
+        subheading = soup.find_all("h2")[-1].text
+
+        # delete class share-float-right
+        for div in soup.find_all("div", {"class": "share-float-right"}):
+            div.decompose()
+
+        # delete h3 u--mtop0 - the subheading caught above
+        for h3 in soup.find_all("h2", {"class": "h3 u--mtop0"}):
+            h3.decompose()
+
+        # the last rich text div is the content
+        speech = soup.find_all("div", {"class": "rich-text"})[-1]
+        speech_tree = etree.fromstring(str(speech))
+
+        # create a new tree, that has a agenda_item as the root
+        # with the id, heading and subheading as attributes
+
+        major_minor_id = f"a{self.committee_date_id}.{speech_id}"
+
+        root = etree.Element(
+            "agenda_item",
+            id=major_minor_id,
+            url=url,
+            heading_title=heading,
+            title=subheading,
+        )
+
+        # create raw_html element
+        raw_html = etree.Element("raw_html")
+        # transfer the contents of the speech tree to the new tree
+        for child in speech_tree:
+            raw_html.append(child)
+
+        root.append(raw_html)
+
+        return root
+
+    def construct_xml(self) -> etree.Element:
+        """
+        Create the XML structure for storing all agenda items discussed
+        by the committee on that day.
+        """
+        major_url = scot_prefix + major_heading_url.format(
+            slug=self.committee_date_slug, id=self.committee_date_id
+        )
+
+        items = []
+
+        for url in self.urls():
+            items.append(self.get_debate_item_content(str(self.items[0]), url))
+
+        # get major heading title
+        heading_title = items[0].attrib["heading_title"]
+
+        root = etree.Element(
+            "committee",
+            url=major_url,
+            title=heading_title,
+            date=self.date,
+            committee=self.committee_date_slug,
+            id=f"c{self.committee_date_id}.0",
+        )
+
+        for item in items:
+            root.append(item)
+
+        etree.indent(root, space="    ")
+
+        return root
+
+    def save_xml(self, cache_dir: Path, override: bool = False) -> Path:
+        """
+        Generated interim xml file and save it to the cache directory
+        """
+        filename = cache_dir / f"{self.date}-{self.committee_date_slug}.xml"
+        if filename.exists() is False or override:
+            xml = self.construct_xml()
+            with filename.open("wb") as f:
+                f.write(etree.tostring(xml))
+        return filename
+
+
+def fetch_debates_for_dates(
+    start_date: str,
+    end_date: str,
+    cache_dir: Path,
+    verbose: bool = False,
+    override: bool = False,
+):
+    """
+    Fetch debates across all chambers for a given date range
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    for grouping in get_debate_groupings(start_date, end_date):
+        if verbose:
+            print(f"Fetching debates for {grouping.committee_date_slug}")
+        yield grouping.save_xml(cache_dir=cache_dir, override=override)

--- a/pyscraper/sp_2024/parse.py
+++ b/pyscraper/sp_2024/parse.py
@@ -1,0 +1,275 @@
+"""
+This module contains tools to convert the unstructured HTML of the debates into structured XML.
+This is not the TWFY style XML - but tries to retain all information from the original.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup, Tag
+
+# HTML elements we accept moving from raw_html to parsed
+acceptable_elements = [
+    "a",
+    "abbr",
+    "acronym",
+    "address",
+    "b",
+    "big",
+    "blockquote",
+    "br",
+    "caption",
+    "center",
+    "cite",
+    "col",
+    "colgroup",
+    "dd",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "i",
+    "img",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "q",
+    "s",
+    "small",
+    "span",
+    "strike",
+    "strong",
+    "sub",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "title",
+    "tr",
+    "tt",
+    "u",
+    "ul",
+    "timestamp",
+]
+
+
+def process_raw_html(raw_html: Tag, agenda_item_url: str) -> BeautifulSoup:
+    """
+    Given the debate html, convert it to a structured xml format
+    This isn't yet matching TWFY schema or using the right IDs.
+    The goal is to make a structured file that's a bit easier to work with.
+    """
+
+    # Deal with timestamps that are not inside anything first
+    raw_html = str(raw_html)
+    raw_html = re.sub(
+        "(?m)^\s*(.*?)\s*<br/>\s*<br/>", r"<timestamp>\1</timestamp>", raw_html
+    )
+    soup = BeautifulSoup(raw_html, "html.parser")
+
+    # convert a structure where there's a strong tag with an a inside to a speech tag
+
+    for strong in soup.find_all("strong"):
+        a = strong.find("a")
+
+        if a and a.get("href"):
+            speaker = soup.new_tag("speech")
+            speaker["speaker_name"] = strong.text.strip()
+            speaker["speaker_href"] = a["href"]
+            speaker["speaker_scot_id"] = a["name"]
+            strong.replace_with(speaker)
+        elif a and a.get("name", "") == "0":
+            # This is a speaker without a member link - outside speakers, religious ministers, etc
+            speaker = soup.new_tag("speech")
+            speaker["speaker_name"] = strong.text.strip()
+            strong.replace_with(speaker)
+
+    # if there is a div that just contains a speech
+    # promote the speech tag to the higher level and delete the div
+    for div in soup.find_all("div"):
+        reduced_contents = [x for x in div.contents if str(x).strip() != ""]
+        if len(reduced_contents) == 1 and div.find("speech"):
+            speaker = div.find("speech")
+            div.replace_with(speaker)
+
+    # if there is a p that just contains a speech, promote the speech tag to the higher level
+    # move the id of the p to a speech_link_id attribute on the speech tag
+    for p in soup.find_all("p"):
+        reduced_contents = [x for x in p.contents if str(x).strip() != ""]
+        if len(reduced_contents) == 1 and p.find("speech"):
+            speaker = p.find("speech")
+            speaker["speech_url"] = agenda_item_url + "#" + p["id"]
+            p.replace_with(speaker)
+
+    # This is for finding topical question headings
+    for p in soup.find_all("p", class_="lead"):
+        heading = soup.new_tag("heading")
+        heading.string = p.string
+        heading["url"] = agenda_item_url + "#" + p["id"]
+        p.replace_with(heading)
+
+    # This is a speaker with some meta-speech e.g. "rose-"
+    # or multiple speakers and the like, e.g. "Members: No"
+    for p in soup.find_all("p", class_="or-contribution-box"):
+        bold = p.find(class_="or-bill-section-bold")
+        italic = p.find(class_="or-italic")
+        if bold and bold.text.strip():
+            speech = soup.new_tag("speech")
+            speech["speaker_name"] = bold.text.strip()
+            bold.decompose()
+            text = p.text.strip()
+            new_p = soup.new_tag("p")
+            if italic:
+                new_p["class"] = "italic"
+            new_p.string = text
+            speech.append(new_p)
+            p.replace_with(speech)
+
+    # for all remaining span or-italic, we just want to make these italics
+    for span in soup.find_all("span", class_="or-italic"):
+        del span["class"]
+        span.name = "i"
+
+    # sequential tags from an acceptable element should be grouped together under the speech
+    # to create the speech object
+    for speaker in soup.find_all("speech"):
+        next_sibling = speaker.find_next_sibling()
+        while next_sibling and next_sibling.name in acceptable_elements:
+            # if the class is 'or-contribution-box' remove that class
+            if next_sibling.get("class") == ["or-contribution-box"]:
+                del next_sibling["class"]
+            speaker.append(next_sibling)
+            next_sibling = speaker.find_next_sibling()
+
+    # there are currently timestamps inside speeches
+    # we want to move these after their parent
+    # move these in reverse so that consequentive timestamps
+    # end up in the right order
+    for timestamp in soup.find_all("timestamp")[::-1]:
+        timestamp.parent.insert_after(timestamp)
+
+    # now, in each speech - we want to iterate through and check for a p tag that's just 'For' or 'Against'
+    # if so the next sibling will be a list of speakers seperated by <br/>
+    # we want to create a msplist tag, with a direction of 'For' or 'Against'
+    # and then a list of speakers as 'mspname' tags
+    for speaker in soup.find_all("speech"):
+        for_tag = speaker.find("p", string="For")
+        against_tag = speaker.find("p", string="Against")
+        abstain_tag = speaker.find("p", string="Abstentions")
+        for vote_tag in [for_tag, against_tag, abstain_tag]:
+            if vote_tag:
+                vote_str = vote_tag.text.lower()
+                vote_div = soup.new_tag("msplist")
+                vote_div["vote"] = vote_str
+                # get all the speakers in the next sibling
+                members = vote_tag.find_next_sibling("p").stripped_strings
+
+                for m in members:
+                    mspname = soup.new_tag("mspname")
+                    mspname["vote"] = vote_str
+                    mspname.string = m
+                    vote_div.append(mspname)
+
+                vote_tag.find_next_sibling("p").decompose()
+                speaker.append(vote_div)
+                vote_tag.decompose()
+
+        # now we want to wrap any sequential msplists tags in a division tag
+        vote_tags = speaker.find_all("msplist")
+        if len(vote_tags) > 1:
+            division_tag = soup.new_tag("division")
+            vote_tags[0].insert_before(division_tag)
+            for vote_tag in vote_tags:
+                division_tag.append(vote_tag)
+
+        # for all division tags, we want to:
+        # - set a sequential divnum for the day
+        # - create a divisioncount object that counts the for, against abstensions
+        # and spoiled ballots (always 0 for sp)
+
+        for div_num, division in enumerate(speaker.find_all("division")):
+            div_counts = {"for": 0, "against": 0, "abstentions": 0, "spoiledvotes": 0}
+            division["divnum"] = div_num
+            divisioncount = soup.new_tag("divisioncount")
+            for vote in division.find_all("mspname"):
+                div_counts[vote["vote"]] += 1
+
+            for k, v in div_counts.items():
+                divisioncount[k] = str(v)
+
+            division.insert(0, divisioncount)
+
+        # all divisions are currently part of the original speech,
+        # we want to split the speech into
+        # two speeches before and after (copy across properties)
+        # and put the division object between them
+        for division in speaker.find_all("division"):
+            parent = division.parent
+            if parent.name != "speech":
+                raise ValueError("Division not in speech")
+
+            division_pos = parent.index(division)
+            before = parent.contents[:division_pos]
+            after = parent.contents[division_pos + 1 :]
+
+            # move division up to be after original speech
+            parent.insert_after(division)
+
+            # reduce the original speech to just the content before the division
+            parent.clear()
+            parent.extend(before)
+
+            # create a new speech element with the content after the division
+            if len(after) > 0:
+                new_speech = soup.new_tag("speech")
+                # get all attrbs from original speech
+                for k, v in speaker.attrs.items():
+                    new_speech[k] = v
+                new_speech.extend(after)
+                division.insert_after(new_speech)
+
+    soup.find("raw_html").name = "parsed"
+
+    return soup
+
+
+def tidy_up_html(xml_path: Path):
+    """
+    For each subsection there is a raw_html child
+    This function will convert the raw_html element to a parsed child.
+    This can be rerun on already downloaded data.
+    """
+
+    with xml_path.open("r") as f:
+        xml = f.read()
+
+    soup = BeautifulSoup(xml, "html.parser")
+
+    for item in soup.find_all("agenda_item"):
+        agenda_item_url = item.get("url")
+
+        # delete any 'parsed' child of the subsection element
+        for child in item.find_all("parsed"):
+            child.decompose()
+
+        # process html
+        raw_html = item.find("raw_html")
+        parsed_data = process_raw_html(raw_html, agenda_item_url=agenda_item_url)
+        item.append(parsed_data.find("parsed"))
+
+    # dump the soup to a file
+    with xml_path.open("w") as f:
+        f.write(soup.prettify())

--- a/pyscraper/sp_2024/resolvenames.py
+++ b/pyscraper/sp_2024/resolvenames.py
@@ -1,0 +1,477 @@
+import datetime
+import json
+import os
+import re
+from typing import Iterable, TypeVar
+
+from ..base_resolver import ResolverBase
+from .common import non_tag_data_in, tidy_string
+
+members_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../..", "members")
+)
+
+T = TypeVar("T")
+
+
+def first(iterable: Iterable[T]) -> T:
+    for element in iterable:
+        if element:
+            return element
+    return None
+
+
+class MemberList(ResolverBase):
+    import_organization_id = "scottish-parliament"
+
+    # This will return a list of person ID strings or None.  If there
+    # are no matches, the list will be empty.  If we recognize a valid
+    # speaker, but that person is not an MSP (e.g. The Convener,
+    # Members, the Lord Advocate, etc.) then we return None.
+
+    # (In fact, it's not at all clear that distinguishing the empty
+    # list and None cases is actually useful.)
+
+    # FIXME: use Set instead of lists
+
+    def match_whole_speaker(self, speaker_name, speaker_date):
+        # lfp = codecs.open("/var/tmp/all-names",'a','utf-8')
+        # lfp.write("%s\t%s\n"%(speaker_date,speaker_name))
+        # lfp.close()
+
+        # if speaker_date:
+        #     print speaker_name+" [on date "+speaker_date + "]"
+        # else:
+        #     print speaker_date+" [no date]"
+
+        party = ""
+        m = re.match(
+            "^(.*) \((Con|Lab|Labour|LD|SNP|SSP|Green|Ind|SSCUP|SCCUP|Sol)\s?\)(.*)$",
+            speaker_name,
+        )
+        if m:
+            speaker_name = m.group(1) + m.group(3)
+            party = m.group(2)
+
+        # print "party is: "+party
+
+        # Now we should have one of the following formats:
+        # <OFFICE> (<NAME>) (<CONS>)    (one occurrence)
+        # <NAME> (<CONS>)
+        # <OFFICE> (<NAME>)
+        # <NAME> (<OFFICE>)             (also rare)
+        # <question no.> <NAME> (<CONS>)
+        # <NAME>
+
+        # Names are typically fullnames: firstname + " " + lastname
+        #                            or: title + " " + lastname
+        #                            or: title + " " + firstname + " " + lastname
+
+        # First, check the first part:
+
+        m = re.search("^([^\(]*)(.*)", speaker_name)
+        first_part = m.group(1).strip()
+        bracketed_parts = m.group(2).strip()
+        ids_from_first_part = memberList.match_string_somehow(
+            first_part, speaker_date, party, False
+        )
+
+        if ids_from_first_part is None and bracketed_parts:
+            ids_from_first_part = memberList.match_string_somehow(
+                bracketed_parts, speaker_date, party, False
+            )
+
+        if ids_from_first_part is None:
+            return None
+        else:
+            if len(ids_from_first_part) == 1:
+                return ids_from_first_part
+            # Otherwise, we try to refine this...
+            ids_so_far = ids_from_first_part
+
+        while len(bracketed_parts) > 0:
+            m = re.search("\(([^\)]*)(\)(.*)|$)", bracketed_parts)
+            if not m:
+                break
+            bracketed_part = m.group(1).strip()
+            # print "   Got bracketed part: "+bracketed_part
+            ids_from_bracketed_part = memberList.match_string_somehow(
+                bracketed_part, speaker_date, party, False
+            )
+            if ids_from_bracketed_part is not None:
+                if len(ids_from_bracketed_part) == 1:
+                    return ids_from_bracketed_part
+                elif len(ids_from_bracketed_part) == 0:
+                    pass
+                else:
+                    if len(ids_so_far) > 0:
+                        # Work out the intersection...
+                        ids_so_far = [
+                            x for x in ids_so_far if x in ids_from_bracketed_part
+                        ]
+                        if len(ids_so_far) == 1:
+                            return ids_so_far
+                    else:
+                        ids_so_far = ids_from_bracketed_part
+                # Otherwise, we try to refine this...
+            else:
+                return None
+
+            if m.group(3):
+                bracketed_parts = m.group(3).strip()
+            else:
+                bracketed_parts = ""
+
+        return ids_so_far
+
+    # This will return a list of person ID strings or None.  If there
+    # are no matches, the list will be empty.  If we recognize a valid
+    # speaker, but that person is not an MSP (e.g. The Convener,
+    # Members, the Lord Advocate, etc.) then we return None.
+
+    # (In fact, it's not at all clear that distinguishing the empty
+    # list and None cases is actually useful.)
+
+    # FIXME: use Set instead of lists
+
+    def match_string_somehow(self, s, date, party, just_name):
+        # in the str '2. Sarah Boyack (Lothian) (Lab)' we want to remove the '2. ' bit
+        s = re.sub(r"^\d+\.\s", "", s)
+
+        s = re.sub("\s{2,}", " ", s)
+
+        s = s.replace("O\u2019", "O'")
+        if s == "Katy Clark" and date >= "2020-09-03":
+            s = "Baroness Clark of Kilwinning"
+
+        member_ids = []
+
+        # Sometimes the names are written Lastname, FirstNames
+        # (particularly in the reports of divisions.
+
+        comma_match = re.match("^([^,]*), (.*)", s)
+        if comma_match:
+            rearranged = comma_match.group(2) + " " + comma_match.group(1)
+            rearranged_result = self.match_string_somehow(
+                rearranged, date, party, just_name
+            )
+            if rearranged_result is not None:
+                if len(rearranged_result) > 0:
+                    return rearranged_result
+            else:
+                return None
+
+        # ... otherwise just carry on without any rearragement.
+
+        if not just_name:
+            office_name = s.replace("The ", "")
+            office_matches = self.offices.get(office_name)
+            if office_matches:
+                for o in office_matches:
+                    if date and (
+                        date < o["start_date"]
+                        or "end_date" not in list(o.keys())
+                        or date >= o["end_date"]
+                    ):
+                        continue
+                    member_ids.append(o["person_id"])
+                if len(member_ids) == 1:
+                    return member_ids[0]
+
+        fullname_matches = self.fullnames.get(s)
+        if fullname_matches:
+            for m in fullname_matches:
+                if date and date < m["start_date"] or date > m["end_date"]:
+                    continue
+                # get the full membership details so we can check the start_reason
+                mem = self.members.get(m["id"])
+                if (
+                    re.search("The Presiding Officer", s)
+                    and mem["start_reason"] != "became_presiding_officer"
+                ):
+                    # There's some ambiguity about which of the
+                    # presiding officers it is in this case...
+                    continue
+                if m["id"] not in member_ids:
+                    member_ids.append(m["id"])
+            if len(member_ids) == 1:
+                return list(map(self.membertoperson, member_ids))
+
+        # Now check if this begins with a title:
+
+        title_match = re.search("^(Mr|Mgr|Sir|Ms|Mrs|Miss|Lord|Dr\.?) (.*)", s)
+        if title_match:
+            title = title_match.group(1)
+            rest_of_name = title_match.group(2)
+
+            if rest_of_name == "Home Robertson":
+                rest_of_name = "John Home Robertson"
+
+            if rest_of_name == "John Munro" or rest_of_name == "Munro":
+                rest_of_name = "John Farquhar Munro"
+
+            # We should probably deal with these by using the title
+            # attributes from sp-members.xml
+
+            if rest_of_name.lower() == "macdonald":
+                if title == "Ms":
+                    rest_of_name = "Margo MacDonald"
+
+            if title == "Dr" and rest_of_name == "Jackson":
+                rest_of_name = "Sylvia Jackson"
+
+            fullname_matches = self.fullnames.get(rest_of_name)
+            if fullname_matches:
+                for m in fullname_matches:
+                    if date and date < m["start_date"] or date > m["end_date"]:
+                        continue
+                    if m["id"] not in member_ids:
+                        member_ids.append(m["id"])
+                if len(member_ids) == 1:
+                    return list(map(self.membertoperson, member_ids))
+
+            # Or if there's a single word, then this is probably just
+            # a last name:
+
+            if re.match("^[^ ]+$", rest_of_name):
+                lastname_matches = self.lastnames.get(rest_of_name)
+                if lastname_matches:
+                    for m in lastname_matches:
+                        if date and date < m["start_date"] or date > m["end_date"]:
+                            continue
+                        if m["id"] not in member_ids:
+                            member_ids.append(m["id"])
+                    if len(member_ids) == 1:
+                        return list(map(self.membertoperson, member_ids))
+
+        if not just_name:
+            constituency_matches = self.constoidmap.get(s)
+            if constituency_matches:
+                for c in constituency_matches:
+                    # print "       Got constituency id: "+c['id']
+                    members = self.considtomembermap.get(c["id"])
+                    for m in members:
+                        if date and date < m["start_date"] or date > m["end_date"]:
+                            continue
+                        if m["id"] not in member_ids:
+                            member_ids.append(m["id"])
+                    if len(member_ids) == 1:
+                        return list(map(self.membertoperson, member_ids))
+
+        # Just return the string for people that aren't members, but
+        # we know are ones we understand.
+
+        if re.search("(Some [mM]embers|A [mM]ember|Several [mM]embers|Members)", s):
+            # print "Got some general group of people..."
+            return None
+
+        if s in ("The Deputy Convener", "The Convener"):
+            return None
+
+        return list(map(self.membertoperson, member_ids))
+
+    def reloadJSON(self):
+        super(MemberList, self).reloadJSON()
+
+        self.import_constituencies("sp-constituencies.json")
+        self.import_people_json()
+
+        self.offices = {}
+        with open(os.path.join(members_dir, "sp-ministers.json")) as fp:
+            offices_json = fp.read()
+            offices = json.loads(offices_json)
+
+        for office in offices:
+            self.offices.setdefault(office["role"], []).append(office)
+
+    def list(self, date=None):
+        if not date:
+            date = datetime.date.today().isoformat()
+        ids = []
+        for m in self.members.values():
+            if "start_date" in m and date >= m["start_date"] and date <= m["end_date"]:
+                ids.append(m["id"])
+        return ids
+
+    def list_all_dates(self):
+        ids = []
+        for m in self.members.values():
+            ids.append(m["id"])
+        return ids
+
+
+memberList = MemberList()
+
+
+member_vote_re = re.compile(
+    """
+        ^                               # Beginning of the string
+        (?P<last_name>[^,\(\)0-9:]+)    # ... last name, >= 1 non-comma characters
+        ,                               # ... then a comma
+        \s*                             # ... and some greedy whitespace
+        (?P<first_names>[^,\(\)0-9:]*?) # ... first names, a minimal match of any characters
+        \s*\(\(?                        # ... an arbitrary amout of whitespace and an open banana
+                                        #     (with possibly an extra open banana)
+        (?P<constituency>[^\(\)0-9:]*?) # ... constituency, a minimal match of any characters
+        \)\s*\(                         # ... close banana, whitespace, open banana
+        (?P<party>\D*?)                 # ... party, a minimal match of any characters
+        \)                              # ... close banana
+        $                               # ... end of the string
+""",
+    re.VERBOSE,
+)
+
+member_vote_fullname_re = re.compile(
+    """
+        ^                               # Beginning of the string
+        (?P<full_name>[^,\(\)0-9:]+)    # ... full name, >= 1 non-comma characters
+        \s*\(\(?                        # ... an arbitrary amout of whitespace and an open banana
+                                        #     (with possibly an extra open banana)
+        (?P<constituency>[^\(\)0-9:]*?) # ... constituency, a minimal match of any characters
+        \)\s*\(                         # ... close banana, whitespace, open banana
+        (?P<party>\D*?)                 # ... party, a minimal match of any characters
+        \)                              # ... close banana
+        $                               # ... end of the string
+""",
+    re.VERBOSE,
+)
+
+member_vote_just_constituency_re = re.compile(
+    """
+        ^                               # Beginning of the string
+        (?P<last_name>[^,\(\)0-9:]+)    # ... last name, >= 1 non-comma characters
+        ,                               # ... then a comma
+        \s*                             # ... and some greedy whitespace
+        (?P<first_names>[^,\(\)0-9:]*?) # ... first names, a minimal match of any characters
+        \s*\(\(?                        # ... an arbitrary amout of whitespace and an open banana
+                                        #     (with possibly an extra open banana)
+        (?P<constituency>[^\(\)0-9:]*?) # ... constituency, a minimal match of any characters
+        \)\s*                           # ... close banana, whitespace
+        $                               # ... end of the string
+""",
+    re.VERBOSE,
+)
+
+SPEAKERS_DEBUG = False
+
+
+def log_speaker(speaker, date, message):
+    if SPEAKERS_DEBUG:
+        with open("speakers.txt", "a") as fp:
+            fp.write(str(date) + ": [" + message + "] " + speaker + "\n")
+
+
+class IDCache:
+    def __init__(self):
+        self.cache = {}
+
+    def check(self, key: str | None) -> None | str:
+        if key is not None:
+            return self.cache.get(key, None)
+        else:
+            return None
+
+    def set(self, key: str | None, value: str):
+        if key:
+            self.cache[key] = value
+        return value
+
+
+id_cache = IDCache()
+
+
+def get_unique_person_id(
+    tidied_speaker: str, on_date: str, lookup_key: str | None = None
+):
+    # check we haven't cached this one first
+    if v := id_cache.check(lookup_key):
+        return v
+
+    ids = memberList.match_whole_speaker(tidied_speaker, str(on_date))
+    if ids is None:
+        # This special return value (None) indicates that the speaker
+        # is something we know about, but not an MSP (e.g Lord
+        # Advocate)
+        return None
+    elif len(ids) == 0:
+        log_speaker(tidied_speaker, str(on_date), "missing")
+        return None
+    elif len(ids) == 1:
+        # cache for future lookup
+        return id_cache.set(lookup_key, ids[0])
+    else:
+        raise Exception(
+            f"The speaker '{tidied_speaker}' could not be resolved, found: {ids}"
+        )
+
+
+def is_member_vote(element: str, vote_date: str, expecting_a_vote=True):
+    """Returns a speaker ID if this looks like a member's vote in a division
+
+    Otherwise returns None.  If it looks like a vote, but the speaker
+    can't be identified, this throws an exception.  As an example:
+
+    >>> is_member_vote('Something random...', '2012-11-12')
+    >>> is_member_vote('Baillie, Jackie (Dumbarton) (Lab)', '2012-11-12')
+    u'uk.org.publicwhip/member/80476'
+    >>> is_member_vote('Alexander, Ms Wendy (Paisley North) (Lab)', '2010-05-12')
+    u'uk.org.publicwhip/member/80281'
+    >>> is_member_vote('Purvis, Jeremy (Tweeddale, Ettrick and Lauderdale)', '2005-05-18')
+    u'uk.org.publicwhip/member/80101'
+
+    Now some examples that should be ignored:
+
+    >>> is_member_vote(': SP 440 (EC Ref No 11766/99, COM(99) 473 final)', '1999-11-23')
+    >>> is_member_vote('SP 666 (EC Ref No 566 99/0225, COM(99) (CNS))', '2000-02-08')
+    >>> is_member_vote('to promote a private bill, the company relied on its general power under section 10(1)(xxxii)', '2006-05-22')
+
+    And one that should throw an exception:
+
+    >>> is_member_vote('Lebowski, Jeffrey (Los Angeles) (The Dude)', '2012-11-12')
+    Traceback (most recent call last):
+      ...
+    Exception: A voting member 'Jeffrey Lebowski (Los Angeles)' couldn't be resolved
+
+    If expecting_a_vote is False, then don't throw an exception if
+    the name can't be resolved:
+
+    >>> is_member_vote('Lebowski, Jeffrey (Los Angeles) (The Dude)', '2012-11-12', expecting_a_vote=False)
+
+    Also try resolving names that aren't comma-reversed:
+
+    >>> is_member_vote('Brian Adam (North-East Scotland) (SNP)', '1999-11-09')
+    u'uk.org.publicwhip/member/80129'
+
+    """
+    tidied = tidy_string(non_tag_data_in(element))
+
+    def from_first_and_last(m):
+        return m and "%s %s (%s)" % (
+            m.group("first_names"),
+            m.group("last_name"),
+            m.group("constituency"),
+        )
+
+    def from_full(m):
+        return m and m.group("full_name")
+
+    vote_matches = (
+        (member_vote_re, from_first_and_last),
+        (member_vote_just_constituency_re, from_first_and_last),
+        (member_vote_fullname_re, from_full),
+    )
+
+    reformed_name = first(
+        processor(regexp.search(tidied)) for regexp, processor in vote_matches
+    )
+
+    if not reformed_name:
+        return None
+    person_id = get_unique_person_id(reformed_name, str(vote_date))
+
+    if person_id is None and expecting_a_vote:
+        print("reformed_name is:", reformed_name)
+        print("vote_date is:", vote_date)
+        raise Exception("A voting member '%s' couldn't be resolved" % (reformed_name,))
+    else:
+        return person_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-beautifulsoup4==4.3.2
+beautifulsoup4==4.12.3
 everypolitician==0.0.13
-lxml==3.4.0
+lxml==5.2.1
 python-dateutil==2.2
 requests[security]==2.21.0
 requests-cache==0.4.13

--- a/scripts/updatedaterange-parse
+++ b/scripts/updatedaterange-parse
@@ -26,8 +26,8 @@ wrans-2014/parse.py --house lords --type statements --out ~/parldata/scrapedxml/
 pyscraper/wa/parse.py ~/parldata/cmpages/senedd ~/parldata/scrapedxml/senedd
 
 # Scottish Parliament:
-cd ~/parlparse/pyscraper/sp
-./parse-official-reports-new.py --from=$FROMDATE --to=$TODATE || RET=1
+cd ~/parlparse/
+python -m pyscraper.sp_2024 debates --parse --convert --start-date $FROMDATE --end-date $TODATE
 
 # London Assembly questions
 #cd ~/parlparse/london-mayors-questions

--- a/scripts/updatedaterange-scrape
+++ b/scripts/updatedaterange-scrape
@@ -24,8 +24,10 @@ cd ~/parlparse/pyscraper
 # Senedd
 wa/scrape.py
 
-cd ~/parlparse/pyscraper/sp
-./get-official-reports-new.py --daily --quiet
+# Scottish Parliament
+cd ~/parlparse
+python -m pyscraper.sp_2024 debates --download --start-date $FROMDATE --end-date $TODATE
+
 
 # Return error code
 exit $RET


### PR DESCRIPTION
This adds a new scraper for the Scottish Parliament's new site.

I've made a new sp_2024 folder and pulled across some of the elements needed for the ID parser.

There are three main steps:

- Download: Uses the search page to find all agendas for that day, download the items of business and composite that into one file per committee.
- Parse: Create structured information from the debates, containing the IDs and information being passed by the SP website. 
- Convert: Convert this structured information into TWFY format, add debate and person_ids.

(common and resolvenames are lightly re-formatted versions of the modules from the old scraper). 

This seems to work as I'd expect for some recent ones - haven't tested actually loading the data.

There's some more special case stuff that could be loaded from the old scraper, but probably makes more sense to bring it across as things break?