### PR TITLE
Render child interests and --no-progress option

### DIFF
--- a/pyscraper/regmem/__main__.py
+++ b/pyscraper/regmem/__main__.py
@@ -14,11 +14,17 @@ def cli():
 @click.option("--chamber", type=str, default="commons")
 @click.option("--force-refresh", is_flag=True)
 @click.option("--quiet", is_flag=True)
+@click.option("--no-progress", is_flag=True)
 def download_all_registers(
-    chamber: str, force_refresh: bool = False, quiet: bool = False
+    chamber: str,
+    force_refresh: bool = False,
+    quiet: bool = False,
+    no_progress: bool = False,
 ):
     if chamber == "commons":
-        commons_process.download_all_registers(force_refresh=force_refresh, quiet=quiet)
+        commons_process.download_all_registers(
+            force_refresh=force_refresh, quiet=quiet, no_progress=no_progress
+        )
     else:
         raise ValueError(f"Unknown chamber: {chamber}")
 
@@ -28,12 +34,17 @@ def download_all_registers(
 @click.option("--date", type=datetime.date)
 @click.option("--force-refresh", is_flag=True)
 @click.option("--quiet", is_flag=True)
+@click.option("--no-progress", is_flag=True)
 def download_register_from_date(
-    chamber: str, date: datetime.date, force_refresh: bool = False, quiet: bool = False
+    chamber: str,
+    date: datetime.date,
+    force_refresh: bool = False,
+    quiet: bool = False,
+    no_progress: bool = False,
 ):
     if chamber == "commons":
         commons_process.download_register_from_date(
-            date, force_refresh=force_refresh, quiet=quiet
+            date, force_refresh=force_refresh, quiet=quiet, no_progress=no_progress
         )
     else:
         raise ValueError(f"Unknown chamber: {chamber}")
@@ -43,12 +54,16 @@ def download_register_from_date(
 @click.option("--chamber", type=str, default="commons")
 @click.option("--force-refresh", is_flag=True)
 @click.option("--quiet", is_flag=True)
+@click.option("--no-progress", is_flag=True)
 def download_latest_register(
-    chamber: str, force_refresh: bool = False, quiet: bool = False
+    chamber: str,
+    force_refresh: bool = False,
+    quiet: bool = False,
+    no_progress: bool = False,
 ):
     if chamber == "commons":
         commons_process.download_latest_register(
-            force_refresh=force_refresh, quiet=quiet
+            force_refresh=force_refresh, quiet=quiet, no_progress=no_progress
         )
     else:
         raise ValueError(f"Unknown chamber: {chamber}")

--- a/pyscraper/regmem/commons/api_models.py
+++ b/pyscraper/regmem/commons/api_models.py
@@ -41,23 +41,37 @@ field_template = Template(
 
 interest_template = Template(
     """
-        <p class="interest-summary">{{ interest.summary|e  }}</p>
+        <div class="interest-item" id="{{ interest.id }}">
+            {% if is_child %}
+                <h6 class="interest-summary">{{ interest.summary|e  }}</h6>
+            {% else %}
+                <h4 class="interest-summary">{{ interest.summary|e  }}</h4>
+            {% endif %}
+            <ul class="interest-details-list">
+            {% for field in interest.present_fields() %}
+                {{field.to_html()}}
+            {% endfor %}
+                {% if interest.registration_date %}
+                <li class="registration-date">Registration Date: {{ interest.registration_date.strftime('%d %B %Y') }}</li>
+                {% endif %}
+                {% if interest.published_date %}
+                <li class="published-date">Published Date: {{ interest.published_date.strftime('%d %B %Y') }}</li>
+                {% endif %}
+                {% if interest.last_updated_date %}
+                <li class="last-updated-date">Last Updated Date: {{ interest.last_updated_date.strftime('%d %B %Y') }}</li>
+                {% endif %}
 
-        <ul class="interest-details-list">
-        {% for field in interest.present_fields() %}
-            {{field.to_html()}}
-        {% endfor %}
-            {% if interest.registration_date %}
-            <li class="registration-date">Registration Date: {{ interest.registration_date.strftime('%d %B %Y') }}</li>
-            {% endif %}
-            {% if interest.published_date %}
-            <li class="published-date">Published Date: {{ interest.published_date.strftime('%d %B %Y') }}</li>
-            {% endif %}
-            {% if interest.last_updated_date %}
-            <li class="last-updated-date">Last Updated Date: {{ interest.last_updated_date.strftime('%d %B %Y') }}</li>
+            </ul>
+            {% if interest.child_items %}
+            <h5 class="child-item-header">Specific work or payments</h5>
+            <div class="interest-child-items" id="parent-{{ interest.id }}">
+                {% for child in interest.child_items %}
+                    {{ child.to_html(is_child=True) }}
+                {% endfor %}
+            </div>
             {% endif %}
 
-        </ul>
+        </div>
 
         """
 )
@@ -201,8 +215,8 @@ class PublishedInterest(BaseModel):
             return self.updated_date[-1]
         return None
 
-    def to_html(self) -> str:
-        result = interest_template.render(interest=self)
+    def to_html(self, is_child: bool = False) -> str:
+        result = interest_template.render(interest=self, is_child=is_child)
 
         # remove blank lines
         result = "\n".join([x for x in result.split("\n") if x.strip()])

--- a/scripts/dailyupdate
+++ b/scripts/dailyupdate
@@ -6,7 +6,7 @@ source ~/parlparse/scripts/consts
 
 # Update register of members interests
 cd ~/parlparse
-poetry run python -m pyscraper.regmem download-all-registers --chamber commons
+poetry run python -m pyscraper.regmem download-all-registers --chamber commons --no-progress
 
 # Get updated members list all-members.xml, in case it changed
 #cd ~/parlparse/members


### PR DESCRIPTION
Adds:

- `--no-progress` option for quieter cron.
- Actually render the child interests in the XML output. 
- Related TWFY PR makes showing the extra data nicer.