### PR TITLE
Scottish Parliament parser fixes

### DIFF
--- a/pyscraper/sp_2024/download.py
+++ b/pyscraper/sp_2024/download.py
@@ -72,7 +72,7 @@ def get_debate_groupings(start_date: str, end_date: str) -> list[DebateGrouping]
             start_date, end_date, search_page
         )
         meeting_urls.extend(page_result_urls)
-        if heading_count < 10:
+        if len(page_result_urls) < 10:
             keep_fetching = False
         else:
             search_page += 1

--- a/pyscraper/sp_2024/parse.py
+++ b/pyscraper/sp_2024/parse.py
@@ -189,9 +189,11 @@ def process_raw_html(raw_html: Tag, agenda_item_url: str) -> BeautifulSoup:
                 speaker.append(vote_div)
                 vote_tag.decompose()
 
-        # now we want to wrap any sequential msplists tags in a division tag
+        # now we want to wrap any group of msplists tags in a division tag
+        # in the scottish parliament all the votes *can* be on one side
+        # and there will be just one msp list
         vote_tags = speaker.find_all("msplist")
-        if len(vote_tags) > 1:
+        if len(vote_tags) > 0:
             division_tag = soup.new_tag("division")
             vote_tags[0].insert_before(division_tag)
             for vote_tag in vote_tags:


### PR DESCRIPTION
Two quick fixes:

1 - We're not always downloading the meetings of the parliament because there are no references to it till the second page. Parser was using the wrong variable to tell it when to stop. Fixed that and it pulls down more consistently. 

2 - In the Scottish Parliament (because of electronic voting) they sometimes hold votes where everyone is on one side of a division. There was an assumption in the parser when converting that there would be at least 2 MSP lists. Changing a 1 to a 0 makes it happy and things get processed correctly. https://github.com/mysociety/parlparse/issues/193