### PR TITLE
Add hook to tell twfy-votes to refresh

### DIFF
--- a/scripts/other-sites-update
+++ b/scripts/other-sites-update
@@ -19,3 +19,10 @@ curl -s -H 'X-Forwarded-For: 127.0.0.1' https://www.theyworkforyou.com/internal/
 # tell Public Whip to update
 PRODSCRIPT=ukparse-morning-update-done.cgi
 curl -s http://www.publicwhip.org.uk/$PRODSCRIPT >/dev/null &
+
+# tell votes.theyworkforyou.com to update
+curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $VOTESREFRESHTOKEN" \
+    -d '{"shortcut":"refresh_daily"}' \
+    https://votes.theyworkforyou.com/webhooks/refresh


### PR DESCRIPTION
Add an extra call to let TWFY-Votes know it can fetch division information. 

A follow-on question about the right way of making that variable accessible here (or is it better to put this in in the twfy repo somewhere with better access to the settings? Or an approach without the token)