### PR TITLE
[sp] Use ID rather than lookup name if present

### DIFF
--- a/pyscraper/sp_2024/convert.py
+++ b/pyscraper/sp_2024/convert.py
@@ -13,7 +13,11 @@ from typing import Optional
 
 from lxml import etree
 
-from .resolvenames import get_unique_person_id, is_member_vote
+from .resolvenames import (
+    get_unique_person_id,
+    is_member_vote,
+    twfy_id_from_scot_parl_id,
+)
 
 
 def slugify(text: str) -> str:
@@ -105,9 +109,15 @@ def convert_xml_to_twfy(file_path: Path, output_dir: Path, verbose: bool = False
             if subitem.tag == "speech":
                 speaker_name = subitem.get("speaker_name")
                 scot_parl_id = subitem.get("speaker_scot_id")
-                person_id = get_unique_person_id(
-                    speaker_name, iso_date, lookup_key=scot_parl_id
-                )
+                if scot_parl_id:
+                    person_id = twfy_id_from_scot_parl_id(scot_parl_id)
+                else:
+                    # if we don't have an id, we need to look it up from name
+                    # in *most cases* this will not be a member - but need it
+                    # for the few cases they leave something in
+                    person_id = get_unique_person_id(
+                        speaker_name, iso_date, lookup_key=speaker_name
+                    )
                 if (
                     person_id is None
                     and speaker_name not in missing_speakers

--- a/pyscraper/sp_2024/resolvenames.py
+++ b/pyscraper/sp_2024/resolvenames.py
@@ -2,7 +2,12 @@ import datetime
 import json
 import os
 import re
+from functools import lru_cache
+from pathlib import Path
 from typing import Iterable, Optional, TypeVar
+
+from mysoc_validator import Popolo
+from mysoc_validator.models.popolo import IdentifierScheme
 
 from ..base_resolver import ResolverBase
 from .common import non_tag_data_in, tidy_string
@@ -10,6 +15,30 @@ from .common import non_tag_data_in, tidy_string
 members_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../..", "members")
 )
+
+
+@lru_cache
+def get_popolo():
+    """
+    Load the Popolo data from the members directory.
+    """
+    popolo_path = Path(members_dir) / "people.json"
+    popolo = Popolo.from_path(popolo_path)
+    return popolo
+
+
+def twfy_id_from_scot_parl_id(scot_parl_id: str) -> Optional[str]:
+    """
+    Convert a Scottish Parliament ID to a TheyWorkForYou ID.
+    """
+    popolo = get_popolo()
+    person = popolo.persons.from_identifier(
+        scot_parl_id, scheme=IdentifierScheme.SCOTPARL
+    )
+    if person:
+        return person.id
+    return None
+
 
 T = TypeVar("T")
 


### PR DESCRIPTION
Resolves issue: https://github.com/mysociety/parlparse/issues/223

If we know the scottish parliament ID, we try and look it up first just using the ID match.

This also then fixes a bug where if the *blank* id is used as a key, it effectively blocks the name matcher when an ID has been left off. 

I've made something a bit messier by introducing the ID matching library from mysoc_validator (given that's used in other places), but otherwise leaving the name validator intact (using a different popolo handler). This seemed more straightforward than adapting the existing matching for an ID lookup. 