### PR TITLE
Fix misalignments and add Senedd IDs

### DIFF
--- a/scripts/welsh-parliament/official-ids.py
+++ b/scripts/welsh-parliament/official-ids.py
@@ -31,6 +31,7 @@ data = ElementTree.fromstring(r.content)
 
 NAME_FIXES = {
     "Eluned Morgan": "Baroness Morgan of Ely",
+    "Dafydd Trystan Davies": "Dafydd Davies",
 }
 
 candidates = []


### PR DESCRIPTION
Adds Senedd IDs to people.json

Needed to fix a few names to align with the offiical version, and set up one person redirect for a duplicate.