### PR TITLE
regmem: add request timeouts to remaining nation scrapers

### DIFF
--- a/pyscraper/regmem/commons/process.py
+++ b/pyscraper/regmem/commons/process.py
@@ -80,7 +80,7 @@ def recursive_fetch(
         send_params = {"Take": take, "Skip": skip}
         if params:
             send_params.update(params)
-        response = requests.get(url, send_params)
+        response = requests.get(url, send_params, timeout=60)
         response.raise_for_status()
         data = response.json()
         target_items = data["totalResults"]
@@ -101,7 +101,7 @@ def get_single_item(
     interest_id: int,
 ) -> CommonsAPIPublishedInterest:
     url = REGISTER_BASE + f"api/v1/Interests/{interest_id}"
-    item = requests.get(url).json()
+    item = requests.get(url, timeout=60).json()
     interest = CommonsAPIPublishedInterest.model_validate(item)
     return interest
 

--- a/pyscraper/regmem/london/process.py
+++ b/pyscraper/regmem/london/process.py
@@ -76,7 +76,7 @@ class LondonRegisters:
 
         full_url = f"{self.member.url}/{roi_end}"
 
-        content = requests.get(full_url).text
+        content = requests.get(full_url, timeout=60).text
 
         soup = BeautifulSoup(content, "html.parser")
 
@@ -129,7 +129,7 @@ class LondonRegisters:
 
         full_url = f"{self.member.url}/{gift_end}"
 
-        content = requests.get(full_url).text
+        content = requests.get(full_url, timeout=60).text
         try:
             dfs = pd.read_html(StringIO(content))
         except ValueError:
@@ -175,7 +175,7 @@ def get_mayor_people():
 
 
 def get_london_people(people_url: str):
-    content = requests.get(people_url).text
+    content = requests.get(people_url, timeout=60).text
 
     soup = BeautifulSoup(content, "html.parser")
     # iterate through all a elements and grab ones that start with href /who-we-are/what-london-assembly-does/london-assembly-members/

--- a/pyscraper/regmem/ni/process.py
+++ b/pyscraper/regmem/ni/process.py
@@ -28,7 +28,7 @@ def fetch_data_remote():
     """
     dataset_path.parent.mkdir(parents=True, exist_ok=True)
 
-    data = requests.post(dataset_url).json()
+    data = requests.post(dataset_url, timeout=60).json()
     dataset_path.write_text(json.dumps(data, indent=2))
 
 

--- a/pyscraper/regmem/scotland/process.py
+++ b/pyscraper/regmem/scotland/process.py
@@ -31,7 +31,7 @@ def get_data(dump_rejected: bool = True):
     Excluding 'rejected' items - which seems right, but might need to be revisited.
     (There's not many.)
     """
-    data = requests.get(dataset_url).json()
+    data = requests.get(dataset_url, timeout=60).json()
     entries = TypeAdapter(list[ScotAPIEntry]).validate_python(data)
     if dump_rejected:
         entries = [


### PR DESCRIPTION
Same defensive change as #272 (Senedd), applied to the London, Commons, Northern Ireland and Scotland scrapers. `requests.get`/`post` without a `timeout` will block indefinitely if the upstream service stalls the TCP connection - the Senedd scraper has been bitten by this already. A 60s timeout means the scheduled job either succeeds or fails loud enough to be noticed.